### PR TITLE
Revert "Polyfills for node env"

### DIFF
--- a/src/RemoteDevTools/index.js
+++ b/src/RemoteDevTools/index.js
@@ -139,9 +139,7 @@ export function enableRemoteDevtools(remoteId) {
   );
 }
 
-const urlParams = new URLSearchParams(
-  typeof window !== "undefined" && window.location.search
-);
+const urlParams = new URLSearchParams(window.location.search);
 
 // @todo Provide a way to disable it if needed
 if (urlParams.has("enable-remote-devtools")) {

--- a/src/SystemManager.js
+++ b/src/SystemManager.js
@@ -1,5 +1,3 @@
-import { performance } from "./polyfills.js";
-
 export class SystemManager {
   constructor(world) {
     this._systems = [];

--- a/src/World.js
+++ b/src/World.js
@@ -2,7 +2,6 @@ import { SystemManager } from "./SystemManager.js";
 import { EntityManager } from "./EntityManager.js";
 import { ComponentManager } from "./ComponentManager.js";
 import { Version } from "./Version.js";
-import { performance } from "./polyfills.js";
 
 export class World {
   constructor() {

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,4 +1,0 @@
-export const performance =
-  typeof window !== "undefined" && typeof window.performance !== "undefined"
-    ? window.performance
-    : require("perf_hooks").performance;


### PR DESCRIPTION
Reverts MozillaReality/ecsy#132

@Nebual I just noticed that using the `require(perf_hooks)` will cause `module not found` on all the examples and related code. 
We should try to find a different solution that doesn't break that.