### PR TITLE
added constructor to System type definition

### DIFF
--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -3,6 +3,10 @@ import { Entity } from "./Entity";
 import { TagComponent } from './TagComponent';
 import { World } from "./World";
 
+interface Attributes {
+    priority?: number;
+}
+
 /**
  * A system that manipulates entities in the world.
  */
@@ -21,6 +25,8 @@ export abstract class System {
       },
     }
   };
+
+  constructor(world: World, attributes?: Attributes);
 
   /**
    * The results of the queries.

--- a/src/World.d.ts
+++ b/src/World.d.ts
@@ -59,5 +59,5 @@ export class World {
   /**
    * Create a new entity
    */
-  createEntity(name: string?):Entity
+  createEntity(name?: string):Entity
 }


### PR DESCRIPTION
I added the System constructor to the type definition file in order to be able to call it in inheriting systems. Without this change, inheriting systems cannot specify a constructor themselves in Typescript because it could only call a default super constructor.

Example:

    class MySystem extends System {

        private myCustomNumber: number;

        constructor(world: World, attributes?: object) {
            super(world, attributes); // <-- Compiler error because System's constructor is not specified in type definition
            this.myCustomNumber = attributes?.myCustomNumber;
        }
    }

As soon as i want to provide custom data to *MySystem* (*myCustomNumber* in the example above) by putting this data into *attributes*, i have to specify a constructor in MySystem.
