### PR TITLE
Fix duplicate system name check

### DIFF
--- a/src/SystemManager.js
+++ b/src/SystemManager.js
@@ -7,9 +7,7 @@ export class SystemManager {
   }
 
   registerSystem(System, attributes) {
-    if (
-      this._systems.find(s => s.constructor.name === System.name) !== undefined
-    ) {
+    if (this.getSystem(System) !== undefined) {
       console.warn(`System '${System.name}' already registered.`);
       return this;
     }

--- a/test/unit/SystemManager.test.js
+++ b/test/unit/SystemManager.test.js
@@ -3,10 +3,35 @@ import test from "ava";
 import { World, System } from "../../src/index.js";
 
 test("registerSystems", t => {
-  var world = new World();
+  let world = new World();
 
   class SystemA extends System {}
   class SystemB extends System {}
+
+  world.registerSystem(SystemA);
+  t.is(world.systemManager._systems.length, 1);
+  world.registerSystem(SystemB);
+  t.is(world.systemManager._systems.length, 2);
+
+  // Can't register twice the same system
+  world.registerSystem(SystemA);
+  t.is(world.systemManager._systems.length, 2);
+});
+
+test("registerSystems with different systems matching names", t => {
+  let world = new World();
+
+  function importSystemA() {
+    class SystemWithCommonName extends System {}
+    return SystemWithCommonName;
+  }
+  function importSystemB() {
+    class SystemWithCommonName extends System {}
+    return SystemWithCommonName;
+  }
+
+  let SystemA = importSystemA();
+  let SystemB = importSystemB();
 
   world.registerSystem(SystemA);
   t.is(world.systemManager._systems.length, 1);


### PR DESCRIPTION
Instead of checking for systems with the same (constructor) name, this change checks for the same constructor, i.e. an `instanceof` check. The problem with the previous approach is that a minification system like `terser` would mangle the class name, now with potentially overlapping system names. Which is perfectly valid in a modern modules-based code base, as the name under which the class is imported by the consumer manners, not under which it is defined within the imported module.