### PR TITLE
Warn if entityAddComponent is a no op

### DIFF
--- a/src/EntityManager.js
+++ b/src/EntityManager.js
@@ -63,7 +63,14 @@ export class EntityManager {
    * @param {Object} values Optional values to replace the default attributes
    */
   entityAddComponent(entity, Component, values) {
-    if (~entity._ComponentTypes.indexOf(Component)) return;
+    if (~entity._ComponentTypes.indexOf(Component)) {
+      console.warn(
+        "Component type already exists on entity.",
+        entity,
+        Component
+      );
+      return;
+    }
 
     entity._ComponentTypes.push(Component);
 


### PR DESCRIPTION
If a user calls `addComponent` but the component type already exists on the entity, `entityAddComponent` will early out and ignore any `values` passed to `addComponent`. This adds a warning if this happens, so that it's easier to track down why the component value doesn't match what is provided to `addComponent`.