### PR TITLE
Include "window" checker and performance.now() 'polyfill' to fix node usage

### DIFF
--- a/src/RemoteDevTools/index.js
+++ b/src/RemoteDevTools/index.js
@@ -1,5 +1,6 @@
 /* global Peer */
 import { injectScript, generateId } from "./utils.js";
+import { hasWindow } from "../Utils.js";
 
 function hookConsoleAndErrors(connection) {
   var wrapFunctions = ["error", "warning", "log"];
@@ -54,6 +55,11 @@ function includeRemoteIdHTML(remoteId) {
 }
 
 export function enableRemoteDevtools(remoteId) {
+  if (!hasWindow) {
+    console.warn("Remote devtools not available outside the browser");
+    return;
+  }
+
   window.generateNewCode = () => {
     window.localStorage.clear();
     remoteId = generateId(6);
@@ -139,9 +145,11 @@ export function enableRemoteDevtools(remoteId) {
   );
 }
 
-const urlParams = new URLSearchParams(window.location.search);
+if (hasWindow) {
+  const urlParams = new URLSearchParams(window.location.search);
 
-// @todo Provide a way to disable it if needed
-if (urlParams.has("enable-remote-devtools")) {
-  enableRemoteDevtools();
+  // @todo Provide a way to disable it if needed
+  if (urlParams.has("enable-remote-devtools")) {
+    enableRemoteDevtools();
+  }
 }

--- a/src/SystemManager.js
+++ b/src/SystemManager.js
@@ -1,3 +1,5 @@
+import { now } from "./Utils.js";
+
 export class SystemManager {
   constructor(world) {
     this._systems = [];
@@ -47,9 +49,9 @@ export class SystemManager {
   executeSystem(system, delta, time) {
     if (system.initialized) {
       if (system.canExecute()) {
-        let startTime = performance.now();
+        let startTime = now();
         system.execute(delta, time);
-        system.executeTime = performance.now() - startTime;
+        system.executeTime = now() - startTime;
         this.lastExecutedSystem = system;
         system.clearEvents();
       }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -35,3 +35,12 @@ export function queryKey(Components) {
 
   return names.sort().join("-");
 }
+
+// Detector for browser's "window"
+export const hasWindow = typeof window !== "undefined";
+
+// performance.now() "polyfill"
+export const now =
+  hasWindow && typeof window.performance !== "undefined"
+    ? performance.now.bind(performance)
+    : Date.now.bind(Date);

--- a/src/World.js
+++ b/src/World.js
@@ -2,6 +2,7 @@ import { SystemManager } from "./SystemManager.js";
 import { EntityManager } from "./EntityManager.js";
 import { ComponentManager } from "./ComponentManager.js";
 import { Version } from "./Version.js";
+import { hasWindow, now } from "./Utils.js";
 
 export class World {
   constructor() {
@@ -13,14 +14,14 @@ export class World {
 
     this.eventQueues = {};
 
-    if (typeof CustomEvent !== "undefined") {
+    if (hasWindow && typeof CustomEvent !== "undefined") {
       var event = new CustomEvent("ecsy-world-created", {
         detail: { world: this, version: Version }
       });
       window.dispatchEvent(event);
     }
 
-    this.lastTime = performance.now();
+    this.lastTime = now();
   }
 
   registerComponent(Component) {
@@ -43,7 +44,7 @@ export class World {
 
   execute(delta, time) {
     if (!delta) {
-      let time = performance.now();
+      let time = now();
       delta = time - this.lastTime;
       this.lastTime = time;
     }

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -1,8 +1,0 @@
-global.performance =
-  typeof performance !== "undefined" ? performance : { now: () => 0 };
-
-global.window = typeof window !== "undefined" ? window : { location: {} };
-
-const common = {};
-
-export default common;

--- a/test/unit/ComponentManager.test.js
+++ b/test/unit/ComponentManager.test.js
@@ -1,4 +1,3 @@
-import "../helpers/common.js";
 import test from "ava";
 import { World } from "../../src/index.js";
 import { FooComponent, BarComponent } from "../helpers/components";

--- a/test/unit/SystemManager.test.js
+++ b/test/unit/SystemManager.test.js
@@ -1,4 +1,3 @@
-import "../helpers/common.js";
 import test from "ava";
 import { World, System } from "../../src/index.js";
 

--- a/test/unit/entity.test.js
+++ b/test/unit/entity.test.js
@@ -1,4 +1,3 @@
-import "../helpers/common.js";
 import test from "ava";
 import { World } from "../../src/index.js";
 import { FooComponent, BarComponent } from "../helpers/components";

--- a/test/unit/entitymanager.test.js
+++ b/test/unit/entitymanager.test.js
@@ -1,4 +1,3 @@
-import "../helpers/common.js";
 import test from "ava";
 import { World } from "../../src";
 

--- a/test/unit/system.test.js
+++ b/test/unit/system.test.js
@@ -1,4 +1,3 @@
-import "../helpers/common.js";
 import test from "ava";
 import { World, System, Not } from "../../src/index.js";
 import {

--- a/test/unit/systemstatecomponents.test.js
+++ b/test/unit/systemstatecomponents.test.js
@@ -1,5 +1,4 @@
 // @todo Define this globally for all the test?
-import "../helpers/common.js";
 import test from "ava";
 import { World, Not, System, SystemStateComponent } from "../../src/index.js";
 import { FooComponent } from "../helpers/components";


### PR DESCRIPTION
- Added `hasWindow` to detect if `window` is defined
- Added `now()` that will fallback to  `Date.now()` if `performance` is not defined
- Fix `remoteDevtools`
- Fix tests and remove `tests/common.js` with the previous globals hook

Should fix #156 and #130 