### PR TITLE
Export Entity as _Entity and allow parameter to be set in World const…

### DIFF
--- a/src/Entity.js
+++ b/src/Entity.js
@@ -6,7 +6,7 @@ const DEBUG = false;
 
 var nextId = 0;
 
-export default class Entity {
+export class Entity {
   constructor(world) {
     this._world = world || null;
 

--- a/src/EntityManager.js
+++ b/src/EntityManager.js
@@ -1,4 +1,3 @@
-import Entity from "./Entity.js";
 import ObjectPool from "./ObjectPool.js";
 import QueryManager from "./QueryManager.js";
 import EventDispatcher from "./EventDispatcher.js";
@@ -22,7 +21,7 @@ export class EntityManager {
     this._queryManager = new QueryManager(this);
     this.eventDispatcher = new EventDispatcher();
     this._entityPool = new ObjectPool(
-      Entity,
+      this.world.options.entityClass,
       this.world.options.entityPoolSize
     );
 

--- a/src/World.js
+++ b/src/World.js
@@ -12,7 +12,7 @@ const DEFAULT_OPTIONS = {
 
 export class World {
   constructor(options = {}) {
-    this.options = Object.assign(DEFAULT_OPTIONS, options);
+    this.options = Object.assign({}, DEFAULT_OPTIONS, options);
 
     this.componentsManager = new ComponentManager(this);
     this.entityManager = new EntityManager(this);

--- a/src/World.js
+++ b/src/World.js
@@ -3,9 +3,11 @@ import { EntityManager } from "./EntityManager.js";
 import { ComponentManager } from "./ComponentManager.js";
 import { Version } from "./Version.js";
 import { hasWindow, now } from "./Utils.js";
+import { Entity } from "./Entity.js";
 
 const DEFAULT_OPTIONS = {
-  entityPoolSize: 0
+  entityPoolSize: 0,
+  entityClass: Entity
 };
 
 export class World {

--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,4 @@ export { createType } from "./CreateType.js";
 export { Types } from "./StandardTypes.js";
 export { Version } from "./Version.js";
 export { enableRemoteDevtools } from "./RemoteDevTools/index.js";
+export { Entity as _Entity } from "./Entity.js";


### PR DESCRIPTION
So we can extend `Entity` and use it directly in our `World` without need to hack anything around. Specially useful for `ecsy-three` (https://github.com/MozillaReality/ecsy-three/pull/9/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json#diff-cdd75a0ffb05a9ef73ab5f70c89d8c87)