### PR TITLE
Add unregisterSystem TS definition into World

### DIFF
--- a/src/World.d.ts
+++ b/src/World.d.ts
@@ -32,6 +32,13 @@ export class World {
    * @param System Type of system to register
    */
   registerSystem<T extends System>(System:SystemConstructor<T>, attributes?: object): this;
+  
+
+  /**
+   * Unregister a system.
+   * @param System Type of system to unregister
+   */
+  unregisterSystem<T extends System>(System:SystemConstructor<T>): this;
 
   /**
    * Get a system registered in this world.


### PR DESCRIPTION
Just like the title says.

It adds the missing typescript definition for World.unregisterSystem();