### PR TITLE
Fix a few typescript definitions

### DIFF
--- a/src/Component.d.ts
+++ b/src/Component.d.ts
@@ -4,8 +4,6 @@ import { PropType } from "./Types";
  * Base class for components.
  */
 
-export type ComponentProps<P> = P | false;
-
 export type ComponentSchemaProp<T> = {
   default?: T;
   type: PropType<T>;
@@ -18,7 +16,7 @@ export type ComponentSchema = {
 export class Component<P> {
   static schema: ComponentSchema;
   static isComponent: true;
-  constructor(props?: ComponentProps<P>);
+  constructor(props?: P | false);
   copy(source: this): this;
   clone(): this;
   reset(): void;
@@ -28,5 +26,5 @@ export class Component<P> {
 export interface ComponentConstructor<P, C extends Component<P>> {
   schema: ComponentSchema;
   isComponent: true;
-  new (props?: ComponentProps<P>): C;
+  new (props?: P | false): C;
 }

--- a/src/World.d.ts
+++ b/src/World.d.ts
@@ -56,7 +56,7 @@ export class World {
    * @param delta Delta time since the last call
    * @param time Elapsed time
    */
-  execute(delta: number, time: number): void;
+  execute(delta?: number, time?: number): void;
 
   /**
    * Resume execution of this world.


### PR DESCRIPTION
- `ComponentProps<P>` was sorta unnecessary and confusing so I removed it. I would still like to know if there's something else that should be done here based on this issue: https://github.com/MozillaReality/ecsy/issues/199
- `world.execute(delta: number, time: number):void` should be `world.execute(delta?: number, time?: number):void`

I'll add more if I find them soon.