### PR TITLE
Allow components to infer types from class

### DIFF
--- a/src/Component.d.ts
+++ b/src/Component.d.ts
@@ -13,7 +13,7 @@ export type ComponentSchema = {
   [propName: string]: ComponentSchemaProp<any>;
 };
 
-export class Component<P> {
+export class Component<P = false> {
   static schema: ComponentSchema;
   static isComponent: true;
   constructor(props?: P | false);

--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -61,7 +61,7 @@ export class Entity {
    */
   addComponent<P, C extends Component<P>>(
     Component: ComponentConstructor<P, C>,
-    values?: P
+    values?: Omit<Partial<C>, "copy" | "clone" | "reset" | "dispose">
   ): this;
 
   /**


### PR DESCRIPTION
This change would allow types to be inferred from class properties instead of needing to define a new type definition.

```javascript
export default class TextBurst extends Component {
  text?: string | number;
  colorHex = "#FFFFFF";
  static schema = {...
}
```

instead of

```javascript
type TextBurstProps = {
  text?: string | number;
  colorHex: string;
};

export default class TextBurst extends Component<TextBurstProps> {
  text?: string | number;
  colorHex = "#FFFFFF";
  static schema = {...
}
```