### PR TITLE
Clean up typings related to component props

### DIFF
--- a/src/Component.d.ts
+++ b/src/Component.d.ts
@@ -13,18 +13,18 @@ export type ComponentSchema = {
   [propName: string]: ComponentSchemaProp<any>;
 };
 
-export class Component<P> {
+export class Component<C> {
   static schema: ComponentSchema;
   static isComponent: true;
-  constructor(props?: P | false);
+  constructor(props?: Partial<Omit<C, keyof Component<any>>> | false);
   copy(source: this): this;
   clone(): this;
   reset(): void;
   dispose(): void;
 }
 
-export interface ComponentConstructor<P, C extends Component<P>> {
+export interface ComponentConstructor<C extends Component<any>> {
   schema: ComponentSchema;
   isComponent: true;
-  new (props?: P | false): C;
+  new (props?: Partial<Omit<C, keyof Component<any>>> | false): C;
 }

--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -19,16 +19,16 @@ export class Entity {
    * @param Component Type of component to get
    * @param includeRemoved Whether a component that is staled to be removed should be also considered
    */
-  getComponent<P, C extends Component<P>>(
-      Component: ComponentConstructor<P, C>,
+  getComponent<C extends Component<any>>(
+      Component: ComponentConstructor<C>,
       includeRemoved?: boolean
   ): C;
 
   /**
    * Get a component that is slated to be removed from this entity.
    */
-  getRemovedComponent<P, C extends Component<P>>(
-      Component: ComponentConstructor<P, C>
+  getRemovedComponent<C extends Component<any>>(
+      Component: ComponentConstructor<C>
   ): C;
 
   /**
@@ -50,8 +50,8 @@ export class Entity {
    * Get a mutable reference to a component on this entity.
    * @param Component Type of component to get
    */
-  getMutableComponent<P, C extends Component<P>>(
-    Component: ComponentConstructor<P, C>
+  getMutableComponent<C extends Component<any>>(
+    Component: ComponentConstructor<C>
   ): C;
 
   /**
@@ -59,9 +59,9 @@ export class Entity {
    * @param Component Type of component to add to this entity
    * @param values Optional values to replace the default attributes on the component
    */
-  addComponent<P, C extends Component<P>>(
-    Component: ComponentConstructor<P, C>,
-    values?: P
+  addComponent<C extends Component<any>>(
+    Component: ComponentConstructor<C>,
+    values?: Partial<Omit<C, keyof Component<any>>>
   ): this;
 
   /**
@@ -69,8 +69,8 @@ export class Entity {
    * @param Component Type of component to remove from this entity
    * @param forceImmediate Whether a component should be removed immediately
    */
-  removeComponent<P, C extends Component<P>>(
-    Component: ComponentConstructor<P, C>,
+  removeComponent<C extends Component<any>>(
+    Component: ComponentConstructor<C>,
     forceImmediate?: boolean
   ): this;
 
@@ -79,8 +79,8 @@ export class Entity {
    * @param Component Type of component
    * @param includeRemoved Whether a component that is staled to be removed should be also considered
    */
-  hasComponent<P, C extends Component<P>>(
-    Component: ComponentConstructor<P, C>,
+  hasComponent<C extends Component<any>>(
+    Component: ComponentConstructor<C>,
     includeRemoved?: boolean
   ): boolean;
 
@@ -88,8 +88,8 @@ export class Entity {
    * Check if the entity has a component that is slated to be removed.
    * @param Component Type of component
    */
-  hasRemovedComponent<P, C extends Component<P>>(
-    Component: ComponentConstructor<P, C>
+  hasRemovedComponent<C extends Component<any>>(
+    Component: ComponentConstructor<C>
   ): boolean;
 
   /**
@@ -97,7 +97,7 @@ export class Entity {
    * @param Components Component types to check
    */
   hasAllComponents(
-    Components: Array<ComponentConstructor<any, any>>
+    Components: Array<ComponentConstructor<any>>
   ): boolean
 
   /**
@@ -105,7 +105,7 @@ export class Entity {
    * @param Components Component types to check
    */
   hasAnyComponents(
-    Components: Array<ComponentConstructor<any, any>>
+    Components: Array<ComponentConstructor<any>>
   ): boolean
 
   /**

--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -17,7 +17,7 @@ export abstract class System {
    */
   static queries: {
     [queryName: string]: {
-      components: (ComponentConstructor<any, any> | NotComponent<any, any>)[],
+      components: (ComponentConstructor<any> | NotComponent<any>)[],
       listen?: {
         added?: boolean,
         removed?: boolean,
@@ -72,12 +72,12 @@ export interface SystemConstructor<T extends System> {
   new (...args: any): T;
 }
 
-export interface NotComponent<P, C extends Component<P>> {
+export interface NotComponent<C extends Component<any>> {
   type: "not",
-  Component: ComponentConstructor<P, C>
+  Component: ComponentConstructor<C>
 }
 
 /**
  * Use the Not class to negate a component query.
  */
-export function Not<P, C extends Component<P>>(Component: ComponentConstructor<P, C>): NotComponent<P, C>;
+export function Not<C extends Component<any>>(Component: ComponentConstructor<C>): NotComponent<C>;

--- a/src/SystemStateComponent.d.ts
+++ b/src/SystemStateComponent.d.ts
@@ -3,11 +3,11 @@ import { Component, ComponentConstructor } from "./Component";
 /**
  * Components that extend the SystemStateComponent are not removed when an entity is deleted.
  */
-export class SystemStateComponent<P> extends Component<P> {
+export class SystemStateComponent<C> extends Component<C> {
   static isSystemStateComponent: true;
 }
 
-export interface SystemStateComponentConstructor<P, C extends Component<P>> extends ComponentConstructor<P, C> {
+export interface SystemStateComponentConstructor<C extends Component<any>> extends ComponentConstructor<C> {
   isSystemStateComponent: true;
   new (): C;
 }

--- a/src/TagComponent.d.ts
+++ b/src/TagComponent.d.ts
@@ -4,11 +4,11 @@ import { Component, ComponentConstructor } from "./Component";
  * Create components that extend TagComponent in order to take advantage of performance optimizations for components
  * that do not store data
  */
-export class TagComponent extends Component<undefined> {
+export class TagComponent extends Component<{}> {
   static isTagComponent: true;
 }
 
-export interface TagComponentConstructor<C extends Component<undefined>> extends ComponentConstructor<undefined, C> {
+export interface TagComponentConstructor<C extends Component<{}>> extends ComponentConstructor<C> {
   isTagComponent: true;
   new (): C;
 }

--- a/src/World.d.ts
+++ b/src/World.d.ts
@@ -26,7 +26,7 @@ export class World {
    * Register a component.
    * @param Component Type of component to register
    */
-  registerComponent<C extends Component<any>>(Component: ComponentConstructor<any, C>, objectPool?: ObjectPool<C> | false): this;
+  registerComponent<C extends Component<any>>(Component: ComponentConstructor<C>, objectPool?: ObjectPool<C> | false): this;
 
   /**
    * Register a system.


### PR DESCRIPTION
This PR is based on the work by @krazyjakee in #205. I've tried to get typechecking working properly for all component props with the minimal boilerplate.

This is the result:

```typescript
// Note you must pass TestComponent (the type of your component) as the generic type
// for props to be typed correctly.
class TestComponent extends Component<TestComponent> {
  // If you are using strict typing you will need to use ! (non-null assertion operator)
  // or ? (optional property). Default properties are set in the constructor for you based on
  // the type of the property or user defined default
  boolProperty!: boolean; 
  optionalNumberProperty?: number;

  static schema = {
    boolProperty: { type: Types.Boolean },
    optionalNumberProperty: { type: Types.Number, default: undefined }
  };
}

// Creating a component via the component constructor:

const component = new TestComponent({ boolProperty: true }); // Properties are type checked and optional

component.boolProperty === true;

if (component.optionalNumberProperty !== undefined) {
  component.optionalNumberProperty += 1;
}

// Creating a component via entity.addComponent:

const world = new World();

const entity = world.createEntity()
  .addComponent(TestComponent, { boolProperty: true }) // Properties are type checked and optional

const entityComponent = entity.getComponent(TestComponent);

entityComponent.boolProperty === true;

if (entityComponent.optionalNumberProperty !== undefined) {
  entityComponent.optionalNumberProperty += 1;
}
```