### PR TITLE
Fix the copyArray method

### DIFF
--- a/src/Types.js
+++ b/src/Types.js
@@ -14,7 +14,7 @@ export const copyArray = (src, dest) => {
   dest.length = 0;
 
   for (let i = 0; i < src.length; i++) {
-    dest.push(dest[i]);
+    dest.push(src[i]);
   }
 
   return dest;


### PR DESCRIPTION
The arrayCopy method copies values from the dest array to the dest array instead of from the src array to the dest array.