### PR TITLE
Replace DEBUG with process.env.NODE_ENV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -836,6 +836,16 @@
         }
       }
     },
+    "@rollup/plugin-replace": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
+      "integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "magic-string": "^0.25.5"
+      }
+    },
     "@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -6589,6 +6599,15 @@
       "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -9872,6 +9891,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spawn-command": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/core": "^7.10.2",
     "@babel/plugin-transform-modules-commonjs": "^7.10.1",
     "@rollup/plugin-node-resolve": "^8.0.1",
+    "@rollup/plugin-replace": "^2.3.3",
     "ava": "^3.9.0",
     "babel-eslint": "^10.0.3",
     "benchmarker-js": "0.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,17 @@
 import json from "rollup-plugin-json";
 import resolve from "@rollup/plugin-node-resolve";
 import { terser } from "rollup-plugin-terser";
+import replace from "@rollup/plugin-replace";
 
 export default [
   {
     input: "src/index.js",
-    plugins: [json({ exclude: ["node_modules/**"] })],
+    plugins: [
+      replace({
+        _DEBUG_: true
+      }),
+      json({ exclude: ["node_modules/**"] })
+    ],
     output: [
       {
         format: "umd",
@@ -35,7 +41,13 @@ export default [
   },
   {
     input: "src/index.js",
-    plugins: [json({ exclude: ["node_modules/**"] }), terser()],
+    plugins: [
+      replace({
+        _DEBUG_: false
+      }),
+      json({ exclude: ["node_modules/**"] }),
+      terser()
+    ],
     output: [
       {
         format: "umd",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,8 @@ export default [
     input: "src/index.js",
     plugins: [
       replace({
-        _DEBUG_: true
+        "process.env.NODE_ENV": JSON.stringify("development"),
+        delimiters: ["", ""]
       }),
       json({ exclude: ["node_modules/**"] })
     ],
@@ -43,7 +44,8 @@ export default [
     input: "src/index.js",
     plugins: [
       replace({
-        _DEBUG_: false
+        "process.env.NODE_ENV": JSON.stringify("production"),
+        delimiters: ["", ""]
       }),
       json({ exclude: ["node_modules/**"] }),
       terser()

--- a/site/docs/manual/Architecture.md
+++ b/site/docs/manual/Architecture.md
@@ -40,6 +40,13 @@ And finally we define the systems that will add the logic to the game:
 
 ![Wolves and dragons example](https://ecsy.io/docs/manual/images/dragons.svg)
 
+## Debug mode
+ECSY will output some debug messages when in development mode. Development mode is active depending on the environment you are running ECSY in.
+
+In CommonJS environments it is controlled by the value of the `NODE_ENV` environment variable. This means Webpack and similar tools can change the value for development and production builds. This ensures you get helpful messages during development and a smaller bundle size in production.
+
+When using the UMD or ES Module builds then the unminified builds will have development mode on and the minified builds will have it turned off.
+
 ## World
 By default your application should have at least one `world`. A world is basically a container for `entities`, `components` and `systems`.  Even so, you can have multiple worlds running at the same time and enable or disable them as you need.
 [API Reference](/api/classes/world).

--- a/site/docs/manual/Architecture.md
+++ b/site/docs/manual/Architecture.md
@@ -393,7 +393,7 @@ Components can be accessed from an entity in two ways:
 - `getComponent(Component)`: Get the component for read only operations.
 - `getMutableComponent(Component)`: Get the component to modify its values.
 
-If `DEBUG` mode is enabled it will throw an error if you try to modify a component accessed by `getComponent`, but that error will not be thrown on release mode because of performance reasons.
+If `development` mode is enabled it will throw an error if you try to modify a component accessed by `getComponent`, but that error will not be thrown on release mode because of performance reasons.
 
 These two access modes help to implement `reactive queries`([more info](/manual/Architecture?id=reactive-queries)), which are basically lists of entities populated with components that have mutated somehow, without much overhead on the execution as we avoid using custom setters or proxies.
 This means every time you request a mutable component, it will get marked as modified and systems listening for that will get notified accordingly.

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -1,9 +1,6 @@
 import Query from "./Query.js";
 import wrapImmutableComponent from "./WrapImmutableComponent.js";
 
-// @todo Take this out from there or use ENV
-const DEBUG = false;
-
 export class Entity {
   constructor(entityManager) {
     this._entityManager = entityManager || null;
@@ -40,7 +37,9 @@ export class Entity {
       component = this._componentsToRemove[Component._typeId];
     }
 
-    return DEBUG ? wrapImmutableComponent(Component, component) : component;
+    return process.env.NODE_ENV !== "production"
+      ? wrapImmutableComponent(Component, component)
+      : component;
   }
 
   getRemovedComponent(Component) {

--- a/src/EntityManager.js
+++ b/src/EntityManager.js
@@ -96,12 +96,13 @@ export class EntityManager {
     }
 
     if (~entity._ComponentTypes.indexOf(Component)) {
-      // @todo Just on debug mode
-      console.warn(
-        "Component type already exists on entity.",
-        entity,
-        Component.getName()
-      );
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          "Component type already exists on entity.",
+          entity,
+          Component.getName()
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
I saw a few `@todo` comments in the code about this so thought I would have a go at implementing something.

- [x] Replace `_DEBUG_` with `process.env.NODE_ENV`
- [x] Add `@rollup/plugin-replace` plugin
- [x] For UMD and ES Module builds made with Rollup, replace `process.env.NODE_ENV` with development for unminified builds and `production` for minified builds
- [x] Add not to architecture docs

I thought this change made sense as CommonJS users can have `process.env.NODE_ENV` controlled by Webpack/Parcel/Rollup to have debug code automatically removed in a production build similar to React. UMD/ES Module users get a similar experience by switching between the unminified and minified builds.

Going forward it means ECSY can start to add more debug code to functions for better DX but can keep bundle size low.