### PR TITLE
Update types for World.getSystem() to return the type of System requested

### DIFF
--- a/src/World.d.ts
+++ b/src/World.d.ts
@@ -44,7 +44,7 @@ export class World {
    * Get a system registered in this world.
    * @param System Type of system to get.
    */
-  getSystem<S extends System>(System: SystemConstructor<S>): System;
+  getSystem<S extends System>(System: SystemConstructor<S>): S;
 
   /**
    * Get a list of systems registered in this world.


### PR DESCRIPTION
Currently the types for World.getSystem() say it returns a generic System.

This updates the types to clarify that it returns the type of System requested.