### PR TITLE
Fix query collision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2275,11 +2275,6 @@
             "pump": "^3.0.0"
           }
         },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        },
         "lowercase-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -6520,9 +6515,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.zip": {

--- a/site/examples/ball-example/three/index.html
+++ b/site/examples/ball-example/three/index.html
@@ -25,14 +25,6 @@
     var world = new World();
 
     world
-      .registerSystem(RotatingSystem)
-      .registerSystem(PulsatingColorSystem)
-      .registerSystem(PulsatingScaleSystem)
-      .registerSystem(TimeoutSystem)
-      .registerSystem(ColliderSystem)
-      .registerSystem(MovingSystem);
-
-    world
       .registerComponent(Object3D)
       .registerComponent(Collidable)
       .registerComponent(Collider)
@@ -43,6 +35,14 @@
       .registerComponent(PulsatingColor)
       .registerComponent(Colliding)
       .registerComponent(Rotating);
+
+    world
+      .registerSystem(RotatingSystem)
+      .registerSystem(PulsatingColorSystem)
+      .registerSystem(PulsatingScaleSystem)
+      .registerSystem(TimeoutSystem)
+      .registerSystem(ColliderSystem)
+      .registerSystem(MovingSystem);
 
     var camera, scene, renderer, parent;
     var clock = new THREE.Clock();
@@ -104,7 +104,7 @@
 
       var geometry = new THREE.BoxBufferGeometry( size, size, size );
 
-      for (var i = 0;i < numObjects; i++) {
+      for (var i = 0; i < numObjects; i++) {
 
         var material = new THREE.MeshStandardMaterial({color: new THREE.Color(1,0,0)});
         var mesh = new THREE.Mesh( geometry, material );

--- a/site/examples/ball-example/three/index.html
+++ b/site/examples/ball-example/three/index.html
@@ -104,7 +104,7 @@
 
       var geometry = new THREE.BoxBufferGeometry( size, size, size );
 
-      for (var i = 0; i < numObjects; i++) {
+      for (var i = 0;i < numObjects; i++) {
 
         var material = new THREE.MeshStandardMaterial({color: new THREE.Color(1,0,0)});
         var mesh = new THREE.Mesh( geometry, material );

--- a/src/System.js
+++ b/src/System.js
@@ -46,7 +46,24 @@ export class System {
         if (!Components || Components.length === 0) {
           throw new Error("'components' attribute can't be empty in a query");
         }
+
+        // Detect if the components have already been registered
+        let unregisteredComponents = Components.filter(
+          Component => Component._typeId === undefined
+        );
+
+        if (unregisteredComponents.length > 0) {
+          throw new Error(
+            `Trying to create a query '${
+              this.constructor.name
+            }.${queryName}' with unregistered components: [${unregisteredComponents
+              .map(c => c.getName())
+              .join(", ")}]`
+          );
+        }
+
         var query = this.world.entityManager.queryComponents(Components);
+
         this._queries[queryName] = query;
         if (queryConfig.mandatory === true) {
           this._mandatoryQueries.push(query);

--- a/src/System.js
+++ b/src/System.js
@@ -1,4 +1,5 @@
 import Query from "./Query.js";
+import { componentRegistered } from "./Utils.js";
 
 export class System {
   canExecute() {
@@ -49,12 +50,12 @@ export class System {
 
         // Detect if the components have already been registered
         let unregisteredComponents = Components.filter(
-          Component => Component._typeId === undefined
+          Component => !componentRegistered(Component)
         );
 
         if (unregisteredComponents.length > 0) {
           throw new Error(
-            `Trying to create a query '${
+            `Tried to create a query '${
               this.constructor.name
             }.${queryName}' with unregistered components: [${unregisteredComponents
               .map(c => c.getName())

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -27,9 +27,9 @@ export function queryKey(Components) {
     var T = Components[n];
     if (typeof T === "object") {
       var operator = T.operator === "not" ? "!" : T.operator;
-      names.push(operator + getName(T.Component));
+      names.push(operator + T.Component._typeId);
     } else {
-      names.push(getName(T));
+      names.push(T._typeId);
     }
   }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -22,7 +22,7 @@ export function componentPropertyName(Component) {
  * @private
  */
 export function queryKey(Components) {
-  var names = [];
+  var ids = [];
   for (var n = 0; n < Components.length; n++) {
     var T = Components[n];
 
@@ -32,13 +32,13 @@ export function queryKey(Components) {
 
     if (typeof T === "object") {
       var operator = T.operator === "not" ? "!" : T.operator;
-      names.push(operator + T.Component._typeId);
+      ids.push(operator + T.Component._typeId);
     } else {
-      names.push(T._typeId);
+      ids.push(T._typeId);
     }
   }
 
-  return names.sort().join("-");
+  return ids.sort().join("-");
 }
 
 // Detector for browser's "window"

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -25,6 +25,11 @@ export function queryKey(Components) {
   var names = [];
   for (var n = 0; n < Components.length; n++) {
     var T = Components[n];
+
+    if (!componentRegistered(T)) {
+      throw new Error(`Tried to create a query with an unregistered component`);
+    }
+
     if (typeof T === "object") {
       var operator = T.operator === "not" ? "!" : T.operator;
       names.push(operator + T.Component._typeId);
@@ -44,3 +49,10 @@ export const now =
   hasWindow && typeof window.performance !== "undefined"
     ? performance.now.bind(performance)
     : Date.now.bind(Date);
+
+export function componentRegistered(T) {
+  return (
+    (typeof T === "object" && T.Component._typeId !== undefined) ||
+    (T.isComponent && T._typeId !== undefined)
+  );
+}

--- a/test/unit/Component.test.js
+++ b/test/unit/Component.test.js
@@ -1,5 +1,6 @@
 import test from "ava";
 import { World } from "../../src/World";
+import { System } from "../../src/System";
 import { Component } from "../../src/Component";
 import {
   createType,
@@ -144,4 +145,32 @@ test("unique type ids", t => {
 
   // Verify multiple calls return the same id.
   t.is(ComponentA._typeId, ComponentA._typeId);
+});
+
+test("registering components before systems", t => {
+  class ComponentA extends Component {}
+  class ComponentB extends Component {}
+
+  class SystemA extends System {}
+  SystemA.queries = { S: { components: [ComponentA, ComponentB] } };
+
+  let world = new World();
+
+  const error1 = t.throws(() => {
+    world.registerSystem(SystemA);
+  });
+  t.is(
+    error1.message,
+    "Tried to create a query 'SystemA.S' with unregistered components: [ComponentA, ComponentB]"
+  );
+
+  world.registerComponent(ComponentA);
+
+  const error2 = t.throws(() => {
+    world.registerSystem(SystemA);
+  });
+  t.is(
+    error2.message,
+    "Tried to create a query 'SystemA.S' with unregistered components: [ComponentB]"
+  );
 });

--- a/test/unit/Component.test.js
+++ b/test/unit/Component.test.js
@@ -1,4 +1,5 @@
 import test from "ava";
+import { World } from "../../src/World";
 import { Component } from "../../src/Component";
 import {
   createType,
@@ -123,4 +124,24 @@ test("clone component", t => {
   t.is(destComponent.refWithDefault.value, "test 4");
   t.is(destComponent.jsonWithDefault.value, "test 5");
   t.true(new Vector3(7, 8, 9).equals(destComponent.vector3WithDefault));
+});
+
+test("unique type ids", t => {
+  class ComponentA extends Component {}
+  class ComponentB extends Component {}
+
+  t.assert(ComponentA._typeId === undefined);
+  t.assert(ComponentB._typeId === undefined);
+
+  let world = new World();
+  world.registerComponent(ComponentA).registerComponent(ComponentB);
+
+  t.assert(ComponentA._typeId !== undefined);
+  t.assert(ComponentB._typeId !== undefined);
+
+  // Verify unique between components.
+  t.not(ComponentA._typeId, ComponentB._typeId);
+
+  // Verify multiple calls return the same id.
+  t.is(ComponentA._typeId, ComponentA._typeId);
 });

--- a/test/unit/Queries.test.js
+++ b/test/unit/Queries.test.js
@@ -233,7 +233,7 @@ test("Two components with the same name get unique queries", t => {
   }
   SystemTest.queries = {
     comp1: { components: [Component1] },
-    comp2: { components: [Component2] },
+    comp2: { components: [Component2] }
   };
   world.registerSystem(SystemTest);
 

--- a/test/unit/system.test.js
+++ b/test/unit/system.test.js
@@ -170,7 +170,6 @@ test("Queries with 'Not' operator", t => {
   };
 
   const error = t.throws(() => {
-    debugger;
     world.registerSystem(SystemNotNot);
   });
 

--- a/test/unit/system.test.js
+++ b/test/unit/system.test.js
@@ -170,6 +170,7 @@ test("Queries with 'Not' operator", t => {
   };
 
   const error = t.throws(() => {
+    debugger;
     world.registerSystem(SystemNotNot);
   });
 


### PR DESCRIPTION
Based on the proposal by @zeddic in https://github.com/MozillaReality/ecsy/issues/215 to fix the minification issues.
- It fixes the `Utils.queryKey` function to use `Component._typeId` instead of names, so we don't rely on names anymore other than to throw error or logs.
- We assign the `_typeId` when registering the component, the proposal to use `getTypeId()` and create the id if it doesn't exist, and otherwise just return it has a perf overhead instead of accessing a variable. To solve that I forced the components to be registered before the systems, otherwise an error will be thrown.
- Added tests 