### PR TITLE
Fix types for System's queries changed option

### DIFF
--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -21,7 +21,7 @@ export abstract class System {
       listen?: {
         added?: boolean,
         removed?: boolean,
-        changed?: boolean | Component<any>[],
+        changed?: boolean | ComponentConstructor<any>[],
       },
     }
   };


### PR DESCRIPTION
Developers specify Component constructors here, not component instances.