### PR TITLE
Return more readonly components

### DIFF
--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -52,7 +52,7 @@ export class Entity {
    */
   getMutableComponent<C extends Component<any>>(
     Component: ComponentConstructor<C>
-  ): C;
+  ): C | undefined;
 
   /**
    * Add a component to the entity.

--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -29,7 +29,7 @@ export class Entity {
    */
   getRemovedComponent<C extends Component<any>>(
       Component: ComponentConstructor<C>
-  ): C;
+  ): Readonly<C> | undefined;
 
   /**
    * Get an object containing all the components on this entity, where the object keys are the component types.

--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -20,9 +20,9 @@ export class Entity {
    * @param includeRemoved Whether a component that is staled to be removed should be also considered
    */
   getComponent<C extends Component<any>>(
-      Component: ComponentConstructor<C>,
-      includeRemoved?: boolean
-  ): C;
+    Component: ComponentConstructor<C>,
+    includeRemoved?: boolean
+  ): Readonly<C> | undefined;
 
   /**
    * Get a component that is slated to be removed from this entity.

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -60,6 +60,11 @@ export class Entity {
 
   getMutableComponent(Component) {
     var component = this._components[Component._typeId];
+
+    if (!component) {
+      return;
+    }
+
     for (var i = 0; i < this.queries.length; i++) {
       var query = this.queries[i];
       // @todo accelerate this check. Maybe having query._Components as an object

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -43,7 +43,11 @@ export class Entity {
   }
 
   getRemovedComponent(Component) {
-    return this._componentsToRemove[Component._typeId];
+    const component = this._componentsToRemove[Component._typeId];
+
+    return process.env.NODE_ENV !== "production"
+      ? wrapImmutableComponent(Component, component)
+      : component;
   }
 
   getComponents() {

--- a/test/unit/entity.test.js
+++ b/test/unit/entity.test.js
@@ -193,7 +193,7 @@ test("remove entity", async t => {
   t.is(world.entityManager.count(), 0);
 });
 
-test("get component includeRemoved", async t => {
+test("get component development", async t => {
   var world = new World();
 
   world.registerComponent(FooComponent);
@@ -202,16 +202,43 @@ test("get component includeRemoved", async t => {
   var entity = world.createEntity();
   entity.addComponent(FooComponent);
   const component = entity.getComponent(FooComponent);
+
+  t.throws(() => (component.variableFoo = 4));
+
   entity.removeComponent(FooComponent);
 
   t.is(entity.hasComponent(FooComponent), false);
   t.is(entity.getComponent(FooComponent), undefined);
 
-  t.is(entity.hasRemovedComponent(FooComponent), true);
-  t.deepEqual(entity.getRemovedComponent(FooComponent), component);
+  const removedComponent = entity.getComponent(FooComponent, true);
 
-  t.is(entity.hasComponent(FooComponent, true), true);
-  t.deepEqual(entity.getComponent(FooComponent, true), component);
+  t.throws(() => (removedComponent.variableFoo = 14));
+});
+
+test("get component production", async t => {
+  const oldNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+  var world = new World();
+
+  world.registerComponent(FooComponent);
+
+  // Sync
+  var entity = world.createEntity();
+  entity.addComponent(FooComponent);
+  const component = entity.getComponent(FooComponent);
+
+  t.notThrows(() => (component.variableFoo = 4));
+
+  entity.removeComponent(FooComponent);
+
+  t.is(entity.hasComponent(FooComponent), false);
+  t.is(entity.getComponent(FooComponent), undefined);
+
+  const removedComponent = entity.getComponent(FooComponent, true);
+
+  t.notThrows(() => (removedComponent.variableFoo = 14));
+
+  process.env.NODE_ENV = oldNodeEnv;
 });
 
 test("Delete entity from entitiesByNames", async t => {

--- a/test/unit/entity.test.js
+++ b/test/unit/entity.test.js
@@ -241,6 +241,21 @@ test("get component production", async t => {
   process.env.NODE_ENV = oldNodeEnv;
 });
 
+test("get mutable component", async t => {
+  var world = new World();
+
+  world.registerComponent(FooComponent);
+
+  // Sync
+  var entity = world.createEntity();
+  entity.addComponent(FooComponent);
+  const component = entity.getMutableComponent(FooComponent);
+
+  t.notThrows(() => (component.variableFoo = 4));
+
+  t.deepEqual(entity.getMutableComponent(BarComponent), undefined);
+});
+
 test("Delete entity from entitiesByNames", async t => {
   var world = new World();
 

--- a/test/unit/entity.test.js
+++ b/test/unit/entity.test.js
@@ -241,6 +241,40 @@ test("get component production", async t => {
   process.env.NODE_ENV = oldNodeEnv;
 });
 
+test("get removed component development", async t => {
+  var world = new World();
+
+  world.registerComponent(FooComponent);
+
+  // Sync
+  var entity = world.createEntity();
+  entity.addComponent(FooComponent);
+  entity.removeComponent(FooComponent);
+
+  const component = entity.getRemovedComponent(FooComponent);
+
+  t.throws(() => (component.variableFoo = 4));
+});
+
+test("get removed component production", async t => {
+  const oldNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+  var world = new World();
+
+  world.registerComponent(FooComponent);
+
+  // Sync
+  var entity = world.createEntity();
+  entity.addComponent(FooComponent);
+  entity.removeComponent(FooComponent);
+
+  const component = entity.getRemovedComponent(FooComponent);
+
+  t.notThrows(() => (component.variableFoo = 4));
+
+  process.env.NODE_ENV = oldNodeEnv;
+});
+
 test("get mutable component", async t => {
   var world = new World();
 


### PR DESCRIPTION
Some small changes to help with TypeScript development

- [x] Fix TypeScript types to show that functions can possibly return `undefined` and `Readonly` components
- [x] Return readonly/immutable components in `getRemovedComponent` as well
  * The rationale for this is that `getComponent` could already return a readonly removed component so this should too