### PR TITLE
Remove undefined from getComponent type

### DIFF
--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -22,14 +22,14 @@ export class Entity {
   getComponent<C extends Component<any>>(
     Component: ComponentConstructor<C>,
     includeRemoved?: boolean
-  ): Readonly<C> | undefined;
+  ): Readonly<C>;
 
   /**
    * Get a component that is slated to be removed from this entity.
    */
   getRemovedComponent<C extends Component<any>>(
       Component: ComponentConstructor<C>
-  ): Readonly<C> | undefined;
+  ): Readonly<C>;
 
   /**
    * Get an object containing all the components on this entity, where the object keys are the component types.
@@ -52,7 +52,7 @@ export class Entity {
    */
   getMutableComponent<C extends Component<any>>(
     Component: ComponentConstructor<C>
-  ): C | undefined;
+  ): C;
 
   /**
    * Add a component to the entity.


### PR DESCRIPTION
The undefined union type is technically correct, but makes it really annoying to use in strict mode and there are many other benefits to be gained in strict mode. I think we should try to use the the system query to determine if the entity has the component and only use the undefined union type when we don't know. There may not be a way to do this in typescript though.