### PR TITLE
Added hasRegisteredComponent to World and ComponentManager

### DIFF
--- a/src/ComponentManager.js
+++ b/src/ComponentManager.js
@@ -10,6 +10,10 @@ export class ComponentManager {
     this.nextComponentId = 0;
   }
 
+  hasComponent(Component) {
+    return this.Components.indexOf(Component) !== -1
+  }
+
   registerComponent(Component, objectPool) {
     if (this.Components.indexOf(Component) !== -1) {
       console.warn(

--- a/src/World.d.ts
+++ b/src/World.d.ts
@@ -28,6 +28,12 @@ export class World {
    */
   registerComponent<C extends Component<any>>(Component: ComponentConstructor<C>, objectPool?: ObjectPool<C> | false): this;
 
+/**
+   * Evluate whether a component has been registered to this world or not.
+   * @param Component Type of component to to evaluate
+   */
+  hasRegisteredComponent<C extends Component<any>>(Component: Component<C>): boolean;
+
   /**
    * Register a system.
    * @param System Type of system to register

--- a/src/World.js
+++ b/src/World.js
@@ -42,6 +42,10 @@ export class World {
     return this;
   }
 
+  hasRegisteredComponent(Component) {
+    return this.componentsManager.hasComponent(Component)
+  }
+
   unregisterSystem(System) {
     this.systemManager.unregisterSystem(System);
     return this;


### PR DESCRIPTION
The goal here is to be able to check whether a component has already been registered to the world before adding it, which can be helpful when different init sequences rely on the same components.