### PR TITLE
Add types for system query results

### DIFF
--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -19,10 +19,10 @@ export class Entity<Components extends (Component<any> | undefined) = undefined>
    * @param Component Type of component to get
    * @param includeRemoved Whether a component that is staled to be removed should be also considered
    */
-  getComponent<C extends Components> (
+  getComponent<C extends Components | Component<any>> (
     Component: C extends Component<any> ? ComponentConstructor<C> : ComponentConstructor<any>,
     includeRemoved?: boolean
-  ): C extends undefined ? Readonly<C> | undefined : Readonly<C>;
+  ): C extends Components ? Readonly<C> :  Readonly<C> | undefined;
 
   /**
    * Get a component that is slated to be removed from this entity.
@@ -50,9 +50,9 @@ export class Entity<Components extends (Component<any> | undefined) = undefined>
    * Get a mutable reference to a component on this entity.
    * @param Component Type of component to get
    */
-  getMutableComponent<C extends Components>(
+  getMutableComponent<C extends Components | Component<any>>(
     Component: C extends Component<any> ? ComponentConstructor<C> : ComponentConstructor<any>
-  ): C extends undefined ? C | undefined : C;
+  ): C extends Components ? C :  C | undefined;
 
   /**
    * Add a component to the entity.

--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -3,7 +3,7 @@ import { Component, ComponentConstructor } from "./Component";
 /**
  * An entity in the world.
  */
-export class Entity {
+export class Entity<Components extends (Component<any> | undefined) = undefined> {
   /**
    * A unique ID for this entity.
    */
@@ -19,17 +19,17 @@ export class Entity {
    * @param Component Type of component to get
    * @param includeRemoved Whether a component that is staled to be removed should be also considered
    */
-  getComponent<C extends Component<any>>(
-    Component: ComponentConstructor<C>,
+  getComponent<C extends Components> (
+    Component: C extends Component<any> ? ComponentConstructor<C> : ComponentConstructor<any>,
     includeRemoved?: boolean
-  ): Readonly<C>;
+  ): C extends undefined ? Readonly<C> | undefined : Readonly<C>;
 
   /**
    * Get a component that is slated to be removed from this entity.
    */
   getRemovedComponent<C extends Component<any>>(
       Component: ComponentConstructor<C>
-  ): Readonly<C>;
+  ): Readonly<C> | undefined;
 
   /**
    * Get an object containing all the components on this entity, where the object keys are the component types.
@@ -50,9 +50,9 @@ export class Entity {
    * Get a mutable reference to a component on this entity.
    * @param Component Type of component to get
    */
-  getMutableComponent<C extends Component<any>>(
-    Component: ComponentConstructor<C>
-  ): C;
+  getMutableComponent<C extends Components>(
+    Component: C extends Component<any> ? ComponentConstructor<C> : ComponentConstructor<any>
+  ): C extends undefined ? C | undefined : C;
 
   /**
    * Add a component to the entity.
@@ -130,3 +130,5 @@ export class Entity {
       forceImmediate?: boolean
   ): void;
 }
+
+

--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -43,7 +43,7 @@ export abstract class System<S extends { queries: SystemQueryDefinitions }> {
    * The results of the queries.
    * Should be used inside of execute.
    */
-  queries: { [K in keyof S["queries"]]: SystemQueryResults<InstanceType<Extract<S["queries"][K]["components"][number], ComponentConstructor<Component<any>>>>> }
+  queries: { [K in keyof S["queries"]]: SystemQueryResults<InstanceType<Extract<S["queries"][K]["components"][number], ComponentConstructor<Component<any>>>> | undefined> }
 
   world: World;
   /**

--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -71,16 +71,7 @@ export abstract class System<S extends { queries: SystemQueryDefinitions }> {
 
 export interface SystemConstructor<T extends System<any>> {
   isSystem: true;
-  queries: {
-    [queryName: string]: {
-      components: (ComponentConstructor<any> | NotComponent<any>)[],
-      listen?: {
-        added?: boolean,
-        removed?: boolean,
-        changed?: boolean | ComponentConstructor<any>[],
-      },
-    }
-  };
+  queries: SystemQueryDefinitions;
   new (...args: any): T;
 }
 


### PR DESCRIPTION
This PR adds strict type safety for system query results. Currently ECSY assumes `entity.getComponent(ComponentA)` will always return `ComponentA`, in reality, it may return undefined. However, if the query had `ComponentA` in its components array, we could safely assume that the entity had the component in the system's execute method.

```typescript
import { System, Component } from "ecsy";

class ComponentA extends Component<ComponentA> {
  a!: number;
}

class ComponentB extends Component<ComponentB>{
  b!: number;
}

class ComponentC extends Component<ComponentC> {
  c!: number;
}

// The <typeof MySystem> parameter is optional when you aren't using strict mode.
// The benefit outside of strict mode is that you will get typechecking and autocompletion for query keys like "ab"
class MySystem extends System<typeof MySystem> {
  static queries = {
    ab: {
      components: [ComponentA, ComponentB],
    }
  };

  execute() {
    const entity = this.queries.ab.results[0];

    // ComponentA is in the query
    entity.getComponent(ComponentA).a;
    entity.getMutableComponent(ComponentA).a = 1;
    
    // ComponentC is not in the query so we need to cast it
    (entity.getComponent(ComponentC) as ComponentC).c;
    (entity.getMutableComponent(ComponentC) as ComponentC).c = 1;
    
    // Note casting gets rid of the Readonly type. I'm not sure what to do about that.
    (entity.getComponent(ComponentC) as ComponentC).c = 1; 
  }
}
```