### PR TITLE
Upgrade prettier and fix linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8755,9 +8755,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "http-server": "^0.11.1",
     "nodemon": "^1.19.4",
     "np": "^6.2.4",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "rollup": "^1.29.0",
     "rollup-plugin-json": "^4.0.0",

--- a/site/examples/canvas/components.js
+++ b/site/examples/canvas/components.js
@@ -5,7 +5,7 @@ export class Movement extends Component {}
 
 Movement.schema = {
   velocity: { type: Vector2Type },
-  acceleration: { type: Vector2Type }
+  acceleration: { type: Vector2Type },
 };
 
 export class Circle extends Component {}
@@ -14,7 +14,7 @@ Circle.schema = {
   position: { type: Vector2Type },
   radius: { type: Types.Number },
   velocity: { type: Vector2Type },
-  acceleration: { type: Vector2Type }
+  acceleration: { type: Vector2Type },
 };
 
 export class CanvasContext extends Component {}
@@ -22,17 +22,17 @@ export class CanvasContext extends Component {}
 CanvasContext.schema = {
   ctx: { type: Types.Ref },
   width: { type: Types.Number },
-  height: { type: Types.Number }
+  height: { type: Types.Number },
 };
 
 export class DemoSettings extends Component {}
 
 DemoSettings.schema = {
-  speedMultiplier: { type: Types.Number, default: 0.001 }
+  speedMultiplier: { type: Types.Number, default: 0.001 },
 };
 
 export class Intersecting extends Component {}
 
 Intersecting.schema = {
-  points: { type: Types.Array }
+  points: { type: Types.Array },
 };

--- a/site/examples/canvas/math.js
+++ b/site/examples/canvas/math.js
@@ -1,7 +1,7 @@
 import {
   createType,
   copyCopyable,
-  cloneClonable
+  cloneClonable,
 } from "../../build/ecsy.module.js";
 
 export class Vector2 {
@@ -31,5 +31,5 @@ export const Vector2Type = createType({
   name: "Vector2",
   default: new Vector2(),
   copy: copyCopyable,
-  clone: cloneClonable
+  clone: cloneClonable,
 });

--- a/site/examples/canvas/systems.js
+++ b/site/examples/canvas/systems.js
@@ -4,7 +4,7 @@ import {
   DemoSettings,
   Movement,
   Circle,
-  Intersecting
+  Intersecting,
 } from "./components.js";
 import { fillCircle, drawLine, intersection } from "./utils.js";
 
@@ -50,7 +50,7 @@ export class MovementSystem extends System {
 
 MovementSystem.queries = {
   entities: { components: [Circle, Movement] },
-  context: { components: [CanvasContext, DemoSettings], mandatory: true }
+  context: { components: [CanvasContext, DemoSettings], mandatory: true },
 };
 
 export class IntersectionSystem extends System {
@@ -103,7 +103,7 @@ export class IntersectionSystem extends System {
 }
 
 IntersectionSystem.queries = {
-  entities: { components: [Circle] }
+  entities: { components: [Circle] },
 };
 
 export class Renderer extends System {
@@ -160,5 +160,5 @@ export class Renderer extends System {
 Renderer.queries = {
   circles: { components: [Circle] },
   intersectingCircles: { components: [Intersecting] },
-  context: { components: [CanvasContext], mandatory: true }
+  context: { components: [CanvasContext], mandatory: true },
 };

--- a/src/Component.js
+++ b/src/Component.js
@@ -77,7 +77,7 @@ export class Component {
     const schema = this.constructor.schema;
 
     // Check that the attributes defined in source are also defined in the schema
-    Object.keys(src).forEach(srcKey => {
+    Object.keys(src).forEach((srcKey) => {
       if (!schema.hasOwnProperty(srcKey)) {
         console.warn(
           `Trying to set attribute '${srcKey}' not defined in the '${this.constructor.name}' schema. Please fix the schema, the attribute value won't be set`
@@ -89,6 +89,6 @@ export class Component {
 
 Component.schema = {};
 Component.isComponent = true;
-Component.getName = function() {
+Component.getName = function () {
   return this.displayName || this.name;
 };

--- a/src/ComponentManager.js
+++ b/src/ComponentManager.js
@@ -11,7 +11,7 @@ export class ComponentManager {
   }
 
   hasComponent(Component) {
-    return this.Components.indexOf(Component) !== -1
+    return this.Components.indexOf(Component) !== -1;
   }
 
   registerComponent(Component, objectPool) {

--- a/src/EntityManager.js
+++ b/src/EntityManager.js
@@ -294,14 +294,14 @@ export class EntityManager {
       numComponentPool: Object.keys(this.componentsManager._componentPool)
         .length,
       componentPool: {},
-      eventDispatcher: this.eventDispatcher.stats
+      eventDispatcher: this.eventDispatcher.stats,
     };
 
     for (var ecsyComponentId in this.componentsManager._componentPool) {
       var pool = this.componentsManager._componentPool[ecsyComponentId];
       stats.componentPool[pool.T.getName()] = {
         used: pool.totalUsed(),
-        size: pool.count
+        size: pool.count,
       };
     }
 

--- a/src/EventDispatcher.js
+++ b/src/EventDispatcher.js
@@ -7,7 +7,7 @@ export default class EventDispatcher {
     this._listeners = {};
     this.stats = {
       fired: 0,
-      handled: 0
+      handled: 0,
     };
   }
 

--- a/src/Query.js
+++ b/src/Query.js
@@ -9,7 +9,7 @@ export default class Query {
     this.Components = [];
     this.NotComponents = [];
 
-    Components.forEach(component => {
+    Components.forEach((component) => {
       if (typeof component === "object") {
         this.NotComponents.push(component.Component);
       } else {
@@ -83,10 +83,10 @@ export default class Query {
       key: this.key,
       reactive: this.reactive,
       components: {
-        included: this.Components.map(C => C.name),
-        not: this.NotComponents.map(C => C.name)
+        included: this.Components.map((C) => C.name),
+        not: this.NotComponents.map((C) => C.name),
       },
-      numEntities: this.entities.length
+      numEntities: this.entities.length,
     };
   }
 
@@ -96,7 +96,7 @@ export default class Query {
   stats() {
     return {
       numComponents: this.Components.length,
-      numEntities: this.entities.length
+      numEntities: this.entities.length,
     };
   }
 }

--- a/src/RemoteDevTools/index.js
+++ b/src/RemoteDevTools/index.js
@@ -4,27 +4,27 @@ import { hasWindow } from "../Utils.js";
 
 function hookConsoleAndErrors(connection) {
   var wrapFunctions = ["error", "warning", "log"];
-  wrapFunctions.forEach(key => {
+  wrapFunctions.forEach((key) => {
     if (typeof console[key] === "function") {
       var fn = console[key].bind(console);
       console[key] = (...args) => {
         connection.send({
           method: "console",
           type: key,
-          args: JSON.stringify(args)
+          args: JSON.stringify(args),
         });
         return fn.apply(null, args);
       };
     }
   });
 
-  window.addEventListener("error", error => {
+  window.addEventListener("error", (error) => {
     connection.send({
       method: "error",
       error: JSON.stringify({
         message: error.error.message,
-        stack: error.error.stack
-      })
+        stack: error.error.stack,
+      }),
     });
   });
 }
@@ -82,7 +82,7 @@ export function enableRemoteDevtools(remoteId) {
 
   // This is used to collect the worlds created before the communication is being established
   let worldsBeforeLoading = [];
-  let onWorldCreated = e => {
+  let onWorldCreated = (e) => {
     var world = e.detail.world;
     Version = e.detail.version;
     worldsBeforeLoading.push(world);
@@ -101,21 +101,21 @@ export function enableRemoteDevtools(remoteId) {
           { url: "stun:stun1.l.google.com:19302" },
           { url: "stun:stun2.l.google.com:19302" },
           { url: "stun:stun3.l.google.com:19302" },
-          { url: "stun:stun4.l.google.com:19302" }
-        ]
+          { url: "stun:stun4.l.google.com:19302" },
+        ],
       },
-      debug: 3
+      debug: 3,
     });
 
     peer.on("open", (/* id */) => {
-      peer.on("connection", connection => {
+      peer.on("connection", (connection) => {
         window.__ECSY_REMOTE_DEVTOOLS.connection = connection;
-        connection.on("open", function() {
+        connection.on("open", function () {
           // infoDiv.style.visibility = "hidden";
           infoDiv.innerHTML = "Connected";
 
           // Receive messages
-          connection.on("data", function(data) {
+          connection.on("data", function (data) {
             if (data.type === "init") {
               var script = document.createElement("script");
               script.setAttribute("type", "text/javascript");
@@ -127,9 +127,9 @@ export function enableRemoteDevtools(remoteId) {
                   "ecsy-world-created",
                   onWorldCreated
                 );
-                worldsBeforeLoading.forEach(world => {
+                worldsBeforeLoading.forEach((world) => {
                   var event = new CustomEvent("ecsy-world-created", {
-                    detail: { world: world, version: Version }
+                    detail: { world: world, version: Version },
                   });
                   window.dispatchEvent(event);
                 });
@@ -144,7 +144,7 @@ export function enableRemoteDevtools(remoteId) {
               if (data.returnEval) {
                 connection.send({
                   method: "evalReturn",
-                  value: value
+                  value: value,
                 });
               }
             }

--- a/src/System.js
+++ b/src/System.js
@@ -50,7 +50,7 @@ export class System {
 
         // Detect if the components have already been registered
         let unregisteredComponents = Components.filter(
-          Component => !componentRegistered(Component)
+          (Component) => !componentRegistered(Component)
         );
 
         if (unregisteredComponents.length > 0) {
@@ -58,7 +58,7 @@ export class System {
             `Tried to create a query '${
               this.constructor.name
             }.${queryName}' with unregistered components: [${unregisteredComponents
-              .map(c => c.getName())
+              .map((c) => c.getName())
               .join(", ")}]`
           );
         }
@@ -70,7 +70,7 @@ export class System {
           this._mandatoryQueries.push(query);
         }
         this.queries[queryName] = {
-          results: query.entities
+          results: query.entities,
         };
 
         // Reactive configuration added/removed/changed
@@ -79,11 +79,11 @@ export class System {
         const eventMapping = {
           added: Query.prototype.ENTITY_ADDED,
           removed: Query.prototype.ENTITY_REMOVED,
-          changed: Query.prototype.COMPONENT_CHANGED // Query.prototype.ENTITY_CHANGED
+          changed: Query.prototype.COMPONENT_CHANGED, // Query.prototype.ENTITY_CHANGED
         };
 
         if (queryConfig.listen) {
-          validEvents.forEach(eventName => {
+          validEvents.forEach((eventName) => {
             if (!this.execute) {
               console.warn(
                 `System '${this.getName()}' has defined listen events (${validEvents.join(
@@ -103,7 +103,7 @@ export class System {
                   let eventList = (this.queries[queryName][eventName] = []);
                   query.eventDispatcher.addEventListener(
                     Query.prototype.COMPONENT_CHANGED,
-                    entity => {
+                    (entity) => {
                       // Avoid duplicates
                       if (eventList.indexOf(entity) === -1) {
                         eventList.push(entity);
@@ -151,7 +151,7 @@ export class System {
 
                 query.eventDispatcher.addEventListener(
                   eventMapping[eventName],
-                  entity => {
+                  (entity) => {
                     // @fixme overhead?
                     if (eventList.indexOf(entity) === -1)
                       eventList.push(entity);
@@ -202,7 +202,7 @@ export class System {
       enabled: this.enabled,
       executeTime: this.executeTime,
       priority: this.priority,
-      queries: {}
+      queries: {},
     };
 
     if (this.constructor.queries) {
@@ -211,7 +211,7 @@ export class System {
         let query = this.queries[queryName];
         let queryDefinition = queries[queryName];
         let jsonQuery = (json.queries[queryName] = {
-          key: this._queries[queryName].key
+          key: this._queries[queryName].key,
         });
 
         jsonQuery.mandatory = queryDefinition.mandatory === true;
@@ -226,10 +226,10 @@ export class System {
           jsonQuery.listen = {};
 
           const methods = ["added", "removed", "changed"];
-          methods.forEach(method => {
+          methods.forEach((method) => {
             if (query[method]) {
               jsonQuery.listen[method] = {
-                entities: query[method].length
+                entities: query[method].length,
               };
             }
           });
@@ -242,13 +242,13 @@ export class System {
 }
 
 System.isSystem = true;
-System.getName = function() {
+System.getName = function () {
   return this.displayName || this.name;
 };
 
 export function Not(Component) {
   return {
     operator: "not",
-    Component: Component
+    Component: Component,
   };
 }

--- a/src/SystemManager.js
+++ b/src/SystemManager.js
@@ -57,7 +57,7 @@ export class SystemManager {
   }
 
   getSystem(SystemClass) {
-    return this._systems.find(s => s instanceof SystemClass);
+    return this._systems.find((s) => s instanceof SystemClass);
   }
 
   getSystems() {
@@ -84,12 +84,12 @@ export class SystemManager {
   }
 
   stop() {
-    this._executeSystems.forEach(system => system.stop());
+    this._executeSystems.forEach((system) => system.stop());
   }
 
   execute(delta, time, forcePlay) {
     this._executeSystems.forEach(
-      system =>
+      (system) =>
         (forcePlay || system.enabled) && this.executeSystem(system, delta, time)
     );
   }
@@ -97,14 +97,14 @@ export class SystemManager {
   stats() {
     var stats = {
       numSystems: this._systems.length,
-      systems: {}
+      systems: {},
     };
 
     for (var i = 0; i < this._systems.length; i++) {
       var system = this._systems[i];
       var systemStats = (stats.systems[system.getName()] = {
         queries: {},
-        executeTime: system.executeTime
+        executeTime: system.executeTime,
       });
       for (var name in system.ctx) {
         systemStats.queries[name] = system.ctx[name].stats();

--- a/src/Types.js
+++ b/src/Types.js
@@ -1,6 +1,6 @@
-export const copyValue = src => src;
+export const copyValue = (src) => src;
 
-export const cloneValue = src => src;
+export const cloneValue = (src) => src;
 
 export const copyArray = (src, dest) => {
   if (!src) {
@@ -20,11 +20,11 @@ export const copyArray = (src, dest) => {
   return dest;
 };
 
-export const cloneArray = src => src && src.slice();
+export const cloneArray = (src) => src && src.slice();
 
-export const copyJSON = src => JSON.parse(JSON.stringify(src));
+export const copyJSON = (src) => JSON.parse(JSON.stringify(src));
 
-export const cloneJSON = src => JSON.parse(JSON.stringify(src));
+export const cloneJSON = (src) => JSON.parse(JSON.stringify(src));
 
 export const copyCopyable = (src, dest) => {
   if (!src) {
@@ -38,12 +38,12 @@ export const copyCopyable = (src, dest) => {
   return dest.copy(src);
 };
 
-export const cloneClonable = src => src && src.clone();
+export const cloneClonable = (src) => src && src.clone();
 
 export function createType(typeDefinition) {
   var mandatoryProperties = ["name", "default", "copy", "clone"];
 
-  var undefinedProperties = mandatoryProperties.filter(p => {
+  var undefinedProperties = mandatoryProperties.filter((p) => {
     return !typeDefinition.hasOwnProperty(p);
   });
 
@@ -68,41 +68,41 @@ export const Types = {
     name: "Number",
     default: 0,
     copy: copyValue,
-    clone: cloneValue
+    clone: cloneValue,
   }),
 
   Boolean: createType({
     name: "Boolean",
     default: false,
     copy: copyValue,
-    clone: cloneValue
+    clone: cloneValue,
   }),
 
   String: createType({
     name: "String",
     default: "",
     copy: copyValue,
-    clone: cloneValue
+    clone: cloneValue,
   }),
 
   Array: createType({
     name: "Array",
     default: [],
     copy: copyArray,
-    clone: cloneArray
+    clone: cloneArray,
   }),
 
   Ref: createType({
     name: "Ref",
     default: undefined,
     copy: copyValue,
-    clone: cloneValue
+    clone: cloneValue,
   }),
 
   JSON: createType({
     name: "JSON",
     default: null,
     copy: copyJSON,
-    clone: cloneJSON
-  })
+    clone: cloneJSON,
+  }),
 };

--- a/src/World.js
+++ b/src/World.js
@@ -7,7 +7,7 @@ import { Entity } from "./Entity.js";
 
 const DEFAULT_OPTIONS = {
   entityPoolSize: 0,
-  entityClass: Entity
+  entityClass: Entity,
 };
 
 export class World {
@@ -24,7 +24,7 @@ export class World {
 
     if (hasWindow && typeof CustomEvent !== "undefined") {
       var event = new CustomEvent("ecsy-world-created", {
-        detail: { world: this, version: Version }
+        detail: { world: this, version: Version },
       });
       window.dispatchEvent(event);
     }
@@ -43,7 +43,7 @@ export class World {
   }
 
   hasRegisteredComponent(Component) {
-    return this.componentsManager.hasComponent(Component)
+    return this.componentsManager.hasComponent(Component);
   }
 
   unregisterSystem(System) {
@@ -87,7 +87,7 @@ export class World {
   stats() {
     var stats = {
       entities: this.entityManager.stats(),
-      system: this.systemManager.stats()
+      system: this.systemManager.stats(),
     };
 
     return stats;

--- a/src/WrapImmutableComponent.js
+++ b/src/WrapImmutableComponent.js
@@ -7,7 +7,7 @@ const proxyHandler = {
         prop
       )}" on immutable component. Use .getMutableComponent() to modify a component.`
     );
-  }
+  },
 };
 
 export default function wrapImmutableComponent(T, component) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ export {
   copyJSON,
   cloneJSON,
   copyCopyable,
-  cloneClonable
+  cloneClonable,
 } from "./Types.js";
 export { Version } from "./Version.js";
 export { enableRemoteDevtools } from "./RemoteDevTools/index.js";

--- a/test/helpers/components.js
+++ b/test/helpers/components.js
@@ -4,13 +4,13 @@ import { Types } from "../../src/Types";
 export class FooComponent extends Component {}
 
 FooComponent.schema = {
-  variableFoo: { type: Types.Number }
+  variableFoo: { type: Types.Number },
 };
 
 export class BarComponent extends Component {}
 
 BarComponent.schema = {
-  variableBar: { type: Types.Number }
+  variableBar: { type: Types.Number },
 };
 
 export class EmptyComponent extends Component {}

--- a/test/unit/Component.test.js
+++ b/test/unit/Component.test.js
@@ -6,7 +6,7 @@ import {
   createType,
   copyCopyable,
   cloneClonable,
-  Types
+  Types,
 } from "../../src/Types";
 import { Vector3 } from "../helpers/customtypes";
 
@@ -16,7 +16,7 @@ CustomTypes.Vector3 = createType({
   name: "Vector3",
   default: new Vector3(),
   copy: copyCopyable,
-  clone: cloneClonable
+  clone: cloneClonable,
 });
 
 class TestComponent extends Component {}
@@ -33,16 +33,16 @@ TestComponent.schema = {
   booleanWithDefault: { type: Types.Boolean, default: true },
   refWithDefault: {
     type: Types.Ref,
-    default: { value: "test ref" }
+    default: { value: "test ref" },
   },
   jsonWithDefault: { type: Types.JSON, default: { value: "test json" } },
   vector3WithDefault: {
     type: CustomTypes.Vector3,
-    default: new Vector3(1, 2, 3)
-  }
+    default: new Vector3(1, 2, 3),
+  },
 };
 
-test("default values", t => {
+test("default values", (t) => {
   const component = new TestComponent();
 
   t.is(component.string, "");
@@ -64,7 +64,7 @@ test("default values", t => {
   t.true(new Vector3(1, 2, 3).equals(component.vector3WithDefault));
 });
 
-test("copy component", t => {
+test("copy component", (t) => {
   const srcComponent = new TestComponent();
   srcComponent.string = "abc";
   srcComponent.number = 1;
@@ -96,7 +96,7 @@ test("copy component", t => {
   t.true(new Vector3(7, 8, 9).equals(destComponent.vector3WithDefault));
 });
 
-test("clone component", t => {
+test("clone component", (t) => {
   const srcComponent = new TestComponent();
   srcComponent.string = "abc";
   srcComponent.number = 1;
@@ -127,7 +127,7 @@ test("clone component", t => {
   t.true(new Vector3(7, 8, 9).equals(destComponent.vector3WithDefault));
 });
 
-test("unique type ids", t => {
+test("unique type ids", (t) => {
   class ComponentA extends Component {}
   class ComponentB extends Component {}
 
@@ -147,7 +147,7 @@ test("unique type ids", t => {
   t.is(ComponentA._typeId, ComponentA._typeId);
 });
 
-test("registering components before systems", t => {
+test("registering components before systems", (t) => {
   class ComponentA extends Component {}
   class ComponentB extends Component {}
 

--- a/test/unit/ComponentManager.test.js
+++ b/test/unit/ComponentManager.test.js
@@ -2,7 +2,7 @@ import test from "ava";
 import { World, Component } from "../../src/index.js";
 import { FooComponent, BarComponent } from "../helpers/components";
 
-test("registerComponents", t => {
+test("registerComponents", (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent);
@@ -15,7 +15,7 @@ test("registerComponents", t => {
   t.is(Object.keys(world.componentsManager.Components).length, 2);
 });
 
-test("Register two components with the same name", t => {
+test("Register two components with the same name", (t) => {
   var world = new World();
 
   {

--- a/test/unit/Queries.test.js
+++ b/test/unit/Queries.test.js
@@ -4,7 +4,7 @@ import { FooComponent, BarComponent } from "../helpers/components";
 
 function queriesLength(queries) {
   let result = {};
-  Object.entries(queries).forEach(q => {
+  Object.entries(queries).forEach((q) => {
     const name = q[0];
     const values = q[1];
     result[name] = values.length;
@@ -13,7 +13,7 @@ function queriesLength(queries) {
   return result;
 }
 
-test("Reactive queries with Not operator", t => {
+test("Reactive queries with Not operator", (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent).registerComponent(BarComponent);
@@ -29,17 +29,17 @@ test("Reactive queries with Not operator", t => {
       listen: {
         added: true,
         changed: true,
-        removed: true
-      }
+        removed: true,
+      },
     },
     not: {
       components: [FooComponent, Not(BarComponent)],
       listen: {
         added: true,
         changed: true,
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   // Register empty system
@@ -52,14 +52,14 @@ test("Reactive queries with Not operator", t => {
     added: 0,
     changed: 0,
     removed: 0,
-    results: 0
+    results: 0,
   });
 
   t.deepEqual(queriesLength(system.queries.not), {
     added: 0,
     changed: 0,
     removed: 0,
-    results: 0
+    results: 0,
   });
 
   //
@@ -70,7 +70,7 @@ test("Reactive queries with Not operator", t => {
     added: 0,
     changed: 0,
     removed: 0,
-    results: 0
+    results: 0,
   });
 
   // It matches the `Not(BarComponent)`
@@ -78,7 +78,7 @@ test("Reactive queries with Not operator", t => {
     added: 1,
     changed: 0,
     removed: 0,
-    results: 1
+    results: 1,
   });
 
   // clean up reactive queries
@@ -91,7 +91,7 @@ test("Reactive queries with Not operator", t => {
     added: 1,
     changed: 0,
     removed: 0,
-    results: 1
+    results: 1,
   });
 
   // It does not match `Not(BarComponent)` so it's being removed
@@ -99,7 +99,7 @@ test("Reactive queries with Not operator", t => {
     added: 0,
     changed: 0,
     removed: 1,
-    results: 0
+    results: 0,
   });
 
   // clean up
@@ -111,7 +111,7 @@ test("Reactive queries with Not operator", t => {
     added: 0,
     changed: 0,
     removed: 1,
-    results: 0
+    results: 0,
   });
 
   // It does match `Not(BarComponent)` so it's being added
@@ -119,11 +119,11 @@ test("Reactive queries with Not operator", t => {
     added: 1,
     changed: 0,
     removed: 0,
-    results: 1
+    results: 1,
   });
 });
 
-test("Entity living just within the frame", t => {
+test("Entity living just within the frame", (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent);
@@ -139,9 +139,9 @@ test("Entity living just within the frame", t => {
       listen: {
         added: true,
         changed: true,
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   // Register empty system
@@ -155,7 +155,7 @@ test("Entity living just within the frame", t => {
     added: 0,
     changed: 0,
     removed: 0,
-    results: 0
+    results: 0,
   });
 
   let entity = world.createEntity().addComponent(FooComponent);
@@ -165,7 +165,7 @@ test("Entity living just within the frame", t => {
     added: 1,
     changed: 0,
     removed: 0,
-    results: 1
+    results: 1,
   });
 
   let addedEntity = query.added[0];
@@ -182,7 +182,7 @@ test("Entity living just within the frame", t => {
     added: 1,
     changed: 0,
     removed: 1,
-    results: 0
+    results: 0,
   });
 
   addedEntity = query.added[0];
@@ -206,11 +206,11 @@ test("Entity living just within the frame", t => {
     added: 0,
     changed: 0,
     removed: 0,
-    results: 0
+    results: 0,
   });
 });
 
-test("Two components with the same name get unique queries", t => {
+test("Two components with the same name get unique queries", (t) => {
   const world = new World();
 
   // Create two components that have the same name.
@@ -233,7 +233,7 @@ test("Two components with the same name get unique queries", t => {
   }
   SystemTest.queries = {
     comp1: { components: [Component1] },
-    comp2: { components: [Component2] }
+    comp2: { components: [Component2] },
   };
   world.registerSystem(SystemTest);
 

--- a/test/unit/SystemManager.test.js
+++ b/test/unit/SystemManager.test.js
@@ -1,7 +1,7 @@
 import test from "ava";
 import { World, System } from "../../src/index.js";
 
-test("registerSystems", t => {
+test("registerSystems", (t) => {
   let world = new World();
 
   class SystemA extends System {}
@@ -17,7 +17,7 @@ test("registerSystems", t => {
   t.is(world.systemManager._systems.length, 2);
 });
 
-test("passes attributes to system.init", t => {
+test("passes attributes to system.init", (t) => {
   var world = new World();
 
   const attributes = { test: 10 };
@@ -33,7 +33,7 @@ test("passes attributes to system.init", t => {
   t.deepEqual(system.attributes, attributes);
 });
 
-test("registerSystems with different systems matching names", t => {
+test("registerSystems with different systems matching names", (t) => {
   let world = new World();
 
   function importSystemA() {

--- a/test/unit/createtype.test.js
+++ b/test/unit/createtype.test.js
@@ -2,7 +2,7 @@ import test from "ava";
 import { createType, copyCopyable, cloneClonable } from "../../src/Types";
 import { Vector3 } from "../helpers/customtypes";
 
-test("Create simple type", t => {
+test("Create simple type", (t) => {
   // Empty
   const error1 = t.throws(() => {
     createType({});
@@ -35,18 +35,18 @@ test("Create simple type", t => {
     name: "test",
     default: undefined,
     copy: () => {},
-    clone: () => {}
+    clone: () => {},
   });
   t.not(type, null);
   t.true(type.isType);
 });
 
-test("Create vector3 type", t => {
+test("Create vector3 type", (t) => {
   var CustomVector3 = createType({
     name: "Vector3",
     default: new Vector3(),
     copy: copyCopyable,
-    clone: cloneClonable
+    clone: cloneClonable,
   });
 
   t.true(CustomVector3.isType);

--- a/test/unit/entity.test.js
+++ b/test/unit/entity.test.js
@@ -7,7 +7,7 @@ import { FooComponent, BarComponent } from "../helpers/components";
  * - IDs
  */
 
-test("adding/removing components sync", async t => {
+test("adding/removing components sync", async (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent).registerComponent(BarComponent);
@@ -20,7 +20,7 @@ test("adding/removing components sync", async t => {
   t.true(entity.hasComponent(FooComponent));
   t.false(entity.hasComponent(BarComponent));
   t.deepEqual(
-    Object.values(entity.getComponents()).map(comp => comp.constructor),
+    Object.values(entity.getComponents()).map((comp) => comp.constructor),
     [FooComponent]
   );
 
@@ -33,7 +33,7 @@ test("adding/removing components sync", async t => {
   t.true(entity.hasComponent(BarComponent));
   t.true(entity.hasAllComponents([FooComponent, BarComponent]));
   t.deepEqual(
-    Object.values(entity.getComponents()).map(comp => comp.constructor),
+    Object.values(entity.getComponents()).map((comp) => comp.constructor),
     [FooComponent, BarComponent]
   );
 
@@ -43,7 +43,7 @@ test("adding/removing components sync", async t => {
   t.true(entity.hasComponent(BarComponent));
   t.false(entity.hasAllComponents([FooComponent, BarComponent]));
   t.deepEqual(
-    Object.values(entity.getComponents()).map(comp => comp.constructor),
+    Object.values(entity.getComponents()).map((comp) => comp.constructor),
     [BarComponent]
   );
 
@@ -54,12 +54,12 @@ test("adding/removing components sync", async t => {
   t.false(entity.hasComponent(BarComponent));
   t.false(entity.hasAllComponents([FooComponent, BarComponent]));
   t.deepEqual(
-    Object.values(entity.getComponents()).map(comp => comp.constructor),
+    Object.values(entity.getComponents()).map((comp) => comp.constructor),
     []
   );
 });
 
-test("clearing pooled components", async t => {
+test("clearing pooled components", async (t) => {
   var world, entity;
 
   // Component with no constructor
@@ -67,7 +67,7 @@ test("clearing pooled components", async t => {
   class BazComponent extends Component {}
 
   BazComponent.schema = {
-    spam: { type: Types.String }
+    spam: { type: Types.String },
   };
 
   world = new World();
@@ -145,7 +145,7 @@ test("clearing pooled components", async t => {
   );
 });
 
-test("removing components deferred", async t => {
+test("removing components deferred", async (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent).registerComponent(BarComponent);
@@ -162,11 +162,13 @@ test("removing components deferred", async t => {
   t.false(entity.hasComponent(FooComponent));
   t.false(entity.hasComponent(BarComponent));
   t.deepEqual(
-    Object.values(entity.getComponents()).map(comp => comp.constructor),
+    Object.values(entity.getComponents()).map((comp) => comp.constructor),
     []
   );
   t.deepEqual(
-    Object.values(entity.getComponentsToRemove()).map(comp => comp.constructor),
+    Object.values(entity.getComponentsToRemove()).map(
+      (comp) => comp.constructor
+    ),
     [FooComponent]
   );
 
@@ -174,12 +176,12 @@ test("removing components deferred", async t => {
   t.is(entity.getComponentTypes().length, 0);
   t.false(entity.hasComponent(FooComponent));
   t.deepEqual(
-    Object.values(entity.getComponents()).map(comp => comp.constructor),
+    Object.values(entity.getComponents()).map((comp) => comp.constructor),
     []
   );
 });
 
-test("remove entity", async t => {
+test("remove entity", async (t) => {
   var world = new World();
 
   // Sync
@@ -193,7 +195,7 @@ test("remove entity", async t => {
   t.is(world.entityManager.count(), 0);
 });
 
-test("get component development", async t => {
+test("get component development", async (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent);
@@ -215,7 +217,7 @@ test("get component development", async t => {
   t.throws(() => (removedComponent.variableFoo = 14));
 });
 
-test("get component production", async t => {
+test("get component production", async (t) => {
   const oldNodeEnv = process.env.NODE_ENV;
   process.env.NODE_ENV = "production";
   var world = new World();
@@ -241,7 +243,7 @@ test("get component production", async t => {
   process.env.NODE_ENV = oldNodeEnv;
 });
 
-test("get removed component development", async t => {
+test("get removed component development", async (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent);
@@ -256,7 +258,7 @@ test("get removed component development", async t => {
   t.throws(() => (component.variableFoo = 4));
 });
 
-test("get removed component production", async t => {
+test("get removed component production", async (t) => {
   const oldNodeEnv = process.env.NODE_ENV;
   process.env.NODE_ENV = "production";
   var world = new World();
@@ -275,7 +277,7 @@ test("get removed component production", async t => {
   process.env.NODE_ENV = oldNodeEnv;
 });
 
-test("get mutable component", async t => {
+test("get mutable component", async (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent);
@@ -290,7 +292,7 @@ test("get mutable component", async t => {
   t.deepEqual(entity.getMutableComponent(BarComponent), undefined);
 });
 
-test("Delete entity from entitiesByNames", async t => {
+test("Delete entity from entitiesByNames", async (t) => {
   var world = new World();
 
   // Sync

--- a/test/unit/entitymanager.test.js
+++ b/test/unit/entitymanager.test.js
@@ -1,7 +1,7 @@
 import test from "ava";
 import { World } from "../../src";
 
-test("entity id", t => {
+test("entity id", (t) => {
   var world = new World();
 
   for (var i = 0; i < 10; i++) {
@@ -13,7 +13,7 @@ test("entity id", t => {
   // @todo Check ids
 });
 
-test("deferred entity remove", t => {
+test("deferred entity remove", (t) => {
   var world = new World();
 
   for (let i = 0; i < 10; i++) {

--- a/test/unit/objectpool.test.js
+++ b/test/unit/objectpool.test.js
@@ -4,16 +4,16 @@ import {
   TagComponent,
   World,
   Types,
-  ObjectPool
+  ObjectPool,
 } from "../../src/index";
 
-test("Detecting Pool", t => {
+test("Detecting Pool", (t) => {
   var world = new World();
 
   class NoPoolComponent extends Component {}
   class PoolComponent extends Component {}
   PoolComponent.schema = {
-    num: { type: Types.Number }
+    num: { type: Types.Number },
   };
   class PoolTagComponent extends TagComponent {}
   class CustomPoolComponent extends Component {}
@@ -42,7 +42,7 @@ test("Detecting Pool", t => {
   );
 });
 
-test("ObjectPool", t => {
+test("ObjectPool", (t) => {
   var id = 0;
 
   class T extends Component {

--- a/test/unit/stats.test.js
+++ b/test/unit/stats.test.js
@@ -2,14 +2,14 @@ import test from "ava";
 import { World, System } from "../../src/index.js";
 import { FooComponent, BarComponent } from "../helpers/components";
 
-test("Stats", async t => {
+test("Stats", async (t) => {
   var world = new World();
 
   class SystemA extends System {}
   SystemA.queries = {
     compFoo: { components: [FooComponent] },
     compBar: { components: [BarComponent] },
-    compBtoh: { components: [FooComponent, BarComponent] }
+    compBtoh: { components: [FooComponent, BarComponent] },
   };
 
   world
@@ -33,41 +33,41 @@ test("Stats", async t => {
       queries: {
         0: {
           numComponents: 1,
-          numEntities: 10
+          numEntities: 10,
         },
         1: {
           numComponents: 1,
-          numEntities: 4
+          numEntities: 4,
         },
         "0-1": {
           numComponents: 2,
-          numEntities: 4
-        }
+          numEntities: 4,
+        },
       },
       numComponentPool: 2,
       componentPool: {
         FooComponent: {
           used: 10,
-          size: 12
+          size: 12,
         },
         BarComponent: {
           used: 4,
-          size: 5
-        }
+          size: 5,
+        },
       },
       eventDispatcher: {
         fired: 24,
-        handled: 0
-      }
+        handled: 0,
+      },
     },
     system: {
       numSystems: 1,
       systems: {
         SystemA: {
           queries: {},
-          executeTime: 0
-        }
-      }
-    }
+          executeTime: 0,
+        },
+      },
+    },
   });
 });

--- a/test/unit/system.test.js
+++ b/test/unit/system.test.js
@@ -3,7 +3,7 @@ import { World, System, Not, Component } from "../../src/index.js";
 import {
   FooComponent,
   BarComponent,
-  EmptyComponent
+  EmptyComponent,
 } from "../helpers/components";
 /*
 test("Initialize", t => {
@@ -48,7 +48,7 @@ test("Initialize", t => {
 });
 */
 
-test("Empty queries", t => {
+test("Empty queries", (t) => {
   var world = new World();
 
   // System 1
@@ -63,14 +63,14 @@ test("Empty queries", t => {
   class SystemEmpty3 extends System {}
 
   SystemEmpty3.queries = {
-    entities: {}
+    entities: {},
   };
 
   // System 4
   class SystemEmpty4 extends System {}
 
   SystemEmpty4.queries = {
-    entities: { components: [] }
+    entities: { components: [] },
   };
 
   // Register empty system
@@ -90,7 +90,7 @@ test("Empty queries", t => {
   t.is(error2.message, "'components' attribute can't be empty in a query");
 });
 
-test("Queries", t => {
+test("Queries", (t) => {
   var world = new World();
 
   world
@@ -108,19 +108,19 @@ test("Queries", t => {
   class SystemFoo extends System {}
 
   SystemFoo.queries = {
-    entities: { components: [FooComponent] }
+    entities: { components: [FooComponent] },
   };
 
   class SystemBar extends System {}
 
   SystemBar.queries = {
-    entities: { components: [BarComponent] }
+    entities: { components: [BarComponent] },
   };
 
   class SystemBoth extends System {}
 
   SystemBoth.queries = {
-    entities: { components: [FooComponent, BarComponent] }
+    entities: { components: [FooComponent, BarComponent] },
   };
 
   world
@@ -145,7 +145,7 @@ test("Queries", t => {
   );
 });
 
-test("Queries with 'Not' operator", t => {
+test("Queries with 'Not' operator", (t) => {
   var world = new World();
 
   world
@@ -166,7 +166,7 @@ test("Queries with 'Not' operator", t => {
   class SystemNotNot extends System {}
 
   SystemNotNot.queries = {
-    notFoo: { components: [Not(FooComponent), Not(BarComponent)] }
+    notFoo: { components: [Not(FooComponent), Not(BarComponent)] },
   };
 
   const error = t.throws(() => {
@@ -181,8 +181,8 @@ test("Queries with 'Not' operator", t => {
     fooNotBar: { components: [FooComponent, Not(BarComponent)] },
     emptyNotBar: { components: [EmptyComponent, Not(BarComponent)] },
     emptyNotBarFoo: {
-      components: [EmptyComponent, Not(BarComponent), Not(FooComponent)]
-    }
+      components: [EmptyComponent, Not(BarComponent), Not(FooComponent)],
+    },
   };
 
   world.registerSystem(SystemNotBar);
@@ -203,7 +203,7 @@ test("Queries with 'Not' operator", t => {
   t.is(queries.emptyNotBar.results.length, 5);
 });
 
-test("Queries with sync removal", t => {
+test("Queries with sync removal", (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent).registerComponent(BarComponent);
@@ -228,9 +228,9 @@ test("Queries with sync removal", t => {
     entities: {
       components: [FooComponent],
       listen: {
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   class SystemB extends System {
@@ -246,9 +246,9 @@ test("Queries with sync removal", t => {
     entities: {
       components: [FooComponent],
       listen: {
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   world.registerSystem(SystemA).registerSystem(SystemB);
@@ -283,7 +283,7 @@ test("Queries with sync removal", t => {
   t.is(entitiesRemovedB.length, 8);
 });
 
-test("Queries with deferred removal", t => {
+test("Queries with deferred removal", (t) => {
   var world = new World();
 
   world
@@ -308,9 +308,9 @@ test("Queries with deferred removal", t => {
     entities: {
       components: [FooComponent],
       listen: {
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   class SystemFB extends System {
@@ -327,9 +327,9 @@ test("Queries with deferred removal", t => {
     entities: {
       components: [FooComponent, BarComponent],
       listen: {
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   class SystemB extends System {}
@@ -338,9 +338,9 @@ test("Queries with deferred removal", t => {
     entities: {
       components: [BarComponent],
       listen: {
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   world
@@ -399,7 +399,7 @@ test("Queries with deferred removal", t => {
   t.is(world.entityManager._entities.length, 2);
 });
 
-test("Queries removing multiple components", t => {
+test("Queries removing multiple components", (t) => {
   var world = new World();
 
   world
@@ -414,7 +414,7 @@ test("Queries removing multiple components", t => {
 
   class SystemA extends System {
     execute() {
-      this.queries.entities.removed.forEach(entity => {
+      this.queries.entities.removed.forEach((entity) => {
         t.false(entity.hasComponent(FooComponent));
         t.true(entity.hasRemovedComponent(FooComponent));
       });
@@ -428,12 +428,12 @@ test("Queries removing multiple components", t => {
     entities: {
       components: [FooComponent, BarComponent],
       listen: {
-        removed: true
-      }
+        removed: true,
+      },
     },
     notTest: {
-      components: [Not(FooComponent), BarComponent, EmptyComponent]
-    }
+      components: [Not(FooComponent), BarComponent, EmptyComponent],
+    },
   };
 
   world.registerSystem(SystemA);
@@ -485,7 +485,7 @@ test("Queries removing multiple components", t => {
   t.is(world.entityManager.entitiesToRemove.length, 0);
 });
 
-test("Querries removing deferred components", t => {
+test("Querries removing deferred components", (t) => {
   var world = new World();
 
   world.registerComponent(FooComponent).registerComponent(BarComponent);
@@ -506,9 +506,9 @@ test("Querries removing deferred components", t => {
     entities: {
       components: [FooComponent],
       listen: {
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   class SystemFB extends System {
@@ -525,9 +525,9 @@ test("Querries removing deferred components", t => {
     entities: {
       components: [FooComponent, BarComponent],
       listen: {
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   class SystemB extends System {}
@@ -536,9 +536,9 @@ test("Querries removing deferred components", t => {
     entities: {
       components: [BarComponent],
       listen: {
-        removed: true
-      }
-    }
+        removed: true,
+      },
+    },
   };
 
   world
@@ -599,7 +599,7 @@ test("Querries removing deferred components", t => {
   t.is(world.entityManager.entitiesWithComponentsToRemove.length, 0);
 });
 
-test("Reactive", t => {
+test("Reactive", (t) => {
   var world = new World();
 
   class ReactiveSystem extends System {
@@ -612,9 +612,9 @@ test("Reactive", t => {
       listen: {
         added: true,
         removed: true,
-        changed: [FooComponent, BarComponent]
-      }
-    }
+        changed: [FooComponent, BarComponent],
+      },
+    },
   };
 
   // Register empty system
@@ -623,10 +623,7 @@ test("Reactive", t => {
   world.registerComponent(FooComponent).registerComponent(BarComponent);
 
   for (var i = 0; i < 15; i++) {
-    world
-      .createEntity()
-      .addComponent(FooComponent)
-      .addComponent(BarComponent);
+    world.createEntity().addComponent(FooComponent).addComponent(BarComponent);
   }
 
   var system = world.systemManager.getSystems()[0];
@@ -643,10 +640,7 @@ test("Reactive", t => {
   system.clearEvents();
 
   // Add a new one
-  world
-    .createEntity()
-    .addComponent(FooComponent)
-    .addComponent(BarComponent);
+  world.createEntity().addComponent(FooComponent).addComponent(BarComponent);
 
   t.is(query.added.length, 1);
   world.execute(); // After execute, events should be cleared
@@ -714,11 +708,11 @@ test("Reactive", t => {
   t.is(query.removed.length, 0);
 });
 
-test("Queries with 'mandatory' parameter", t => {
+test("Queries with 'mandatory' parameter", (t) => {
   var counter = {
     a: 0,
     b: 0,
-    c: 0
+    c: 0,
   };
 
   class SystemA extends System {
@@ -728,7 +722,7 @@ test("Queries with 'mandatory' parameter", t => {
   }
 
   SystemA.queries = {
-    entities: { components: [FooComponent], mandatory: false }
+    entities: { components: [FooComponent], mandatory: false },
   };
 
   class SystemB extends System {
@@ -738,7 +732,7 @@ test("Queries with 'mandatory' parameter", t => {
   }
 
   SystemB.queries = {
-    entities: { components: [FooComponent], mandatory: true }
+    entities: { components: [FooComponent], mandatory: true },
   };
 
   class SystemC extends System {
@@ -748,7 +742,7 @@ test("Queries with 'mandatory' parameter", t => {
   }
 
   SystemC.queries = {
-    entities: { components: [BarComponent], mandatory: true }
+    entities: { components: [BarComponent], mandatory: true },
   };
 
   // -------
@@ -782,7 +776,7 @@ test("Queries with 'mandatory' parameter", t => {
   t.deepEqual(counter, { a: 4, b: 2, c: 2 });
 });
 
-test("Get Systems", t => {
+test("Get Systems", (t) => {
   var world = new World();
 
   class SystemA extends System {}
@@ -800,7 +794,7 @@ test("Get Systems", t => {
   t.deepEqual(systems, world.systemManager._systems);
 });
 
-test("Systems without queries", t => {
+test("Systems without queries", (t) => {
   var world = new World();
 
   var counter = 0;
@@ -820,7 +814,7 @@ test("Systems without queries", t => {
   t.is(counter, 10);
 });
 
-test("Systems with component case sensitive", t => {
+test("Systems with component case sensitive", (t) => {
   var world = new World();
 
   class A extends Component {}
@@ -866,14 +860,14 @@ test("Systems with component case sensitive", t => {
   t.deepEqual(counter, { a: 2, A: 2 });
 });
 
-test("Components with the the same name in uppercase and lowercase", t => {
+test("Components with the the same name in uppercase and lowercase", (t) => {
   class B extends Component {}
 
   class b extends Component {}
 
   class S extends System {
     execute() {
-      this.queries.S.results.forEach(entity =>
+      this.queries.S.results.forEach((entity) =>
         console.log(entity.getComponents())
       );
     }
@@ -885,27 +879,24 @@ test("Components with the the same name in uppercase and lowercase", t => {
   world.registerComponent(B).registerComponent(b);
 
   world.registerSystem(S);
-  world
-    .createEntity()
-    .addComponent(B)
-    .addComponent(b);
+  world.createEntity().addComponent(B).addComponent(b);
 
   let query = world.getSystem(S).queries.S;
   let entity = query.results[0];
   let components = entity.getComponents();
 
   t.deepEqual(
-    Object.keys(components).map(c => parseInt(c)),
+    Object.keys(components).map((c) => parseInt(c)),
     [B._typeId, b._typeId]
   );
 
   t.deepEqual(
-    Object.values(components).map(c => c.getName()),
+    Object.values(components).map((c) => c.getName()),
     ["B", "b"]
   );
 });
 
-test("Unregister systems", t => {
+test("Unregister systems", (t) => {
   class SystemA extends System {}
 
   class SystemB extends System {
@@ -927,7 +918,7 @@ test("Unregister systems", t => {
   t.is(world.systemManager._executeSystems.length, 0);
 });
 
-test("Register a system that does not extend System", t => {
+test("Register a system that does not extend System", (t) => {
   class SystemA {}
 
   const world = new World();

--- a/test/unit/systemstatecomponents.test.js
+++ b/test/unit/systemstatecomponents.test.js
@@ -3,7 +3,7 @@ import test from "ava";
 import { World, Not, System, SystemStateComponent } from "../../src/index.js";
 import { FooComponent } from "../helpers/components";
 
-test("reset", t => {
+test("reset", (t) => {
   var world = new World();
 
   class StateComponentA extends SystemStateComponent {}
@@ -13,11 +13,11 @@ test("reset", t => {
 
   class SystemA extends System {
     execute() {
-      this.queries.added.results.forEach(entity => {
+      this.queries.added.results.forEach((entity) => {
         entity.addComponent(StateComponentA);
       });
 
-      this.queries.remove.results.forEach(entity => {
+      this.queries.remove.results.forEach((entity) => {
         entity.removeComponent(StateComponentA);
       });
 
@@ -30,7 +30,7 @@ test("reset", t => {
   SystemA.queries = {
     added: { components: [FooComponent, Not(StateComponentA)] },
     remove: { components: [Not(FooComponent), StateComponentA] },
-    normal: { components: [FooComponent, StateComponentA] }
+    normal: { components: [FooComponent, StateComponentA] },
   };
 
   world.registerSystem(SystemA);


### PR DESCRIPTION
I think vscode is using prettier 2.0 and I've been running into some issues when reformatting code. So I've upgraded us to prettier 2.0 and fixed all the linting errors.

The prettier 2.0 changelog:
https://prettier.io/blog/2020/03/21/2.0.0.html

tldr; they like trailing commas and parens around single parameter arrow functions now.