### PR TITLE
Make getComponent use an optional return type

### DIFF
--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -19,7 +19,7 @@ export class Entity {
    * @param Component Type of component to get
    * @param includeRemoved Whether a component that is staled to be removed should be also considered
    */
-  getComponent<C extends Component<any>>(
+  getComponent?<C extends Component<any>>(
     Component: ComponentConstructor<C>,
     includeRemoved?: boolean
   ): Readonly<C>;
@@ -27,7 +27,7 @@ export class Entity {
   /**
    * Get a component that is slated to be removed from this entity.
    */
-  getRemovedComponent<C extends Component<any>>(
+  getRemovedComponent?<C extends Component<any>>(
       Component: ComponentConstructor<C>
   ): Readonly<C>;
 
@@ -50,7 +50,7 @@ export class Entity {
    * Get a mutable reference to a component on this entity.
    * @param Component Type of component to get
    */
-  getMutableComponent<C extends Component<any>>(
+  getMutableComponent?<C extends Component<any>>(
     Component: ComponentConstructor<C>
   ): C;
 

--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -7,6 +7,17 @@ interface Attributes {
   [propName: string]: any;
 }
 
+export interface SystemQueries {
+  [queryName: string]: {
+    components: (ComponentConstructor<any> | NotComponent<any>)[],
+    listen?: {
+      added?: boolean,
+      removed?: boolean,
+      changed?: boolean | ComponentConstructor<any>[],
+    },
+  }
+}
+
 /**
  * A system that manipulates entities in the world.
  */
@@ -15,16 +26,7 @@ export abstract class System {
    * Defines what Components the System will query for.
    * This needs to be user defined.
    */
-  static queries: {
-    [queryName: string]: {
-      components: (ComponentConstructor<any> | NotComponent<any>)[],
-      listen?: {
-        added?: boolean,
-        removed?: boolean,
-        changed?: boolean | ComponentConstructor<any>[],
-      },
-    }
-  };
+  static queries: SystemQueries;
 
   static isSystem: true;
 
@@ -69,6 +71,7 @@ export abstract class System {
 
 export interface SystemConstructor<T extends System> {
   isSystem: true;
+  queries: SystemQueries
   new (...args: any): T;
 }
 


### PR DESCRIPTION
`getComponent`, `getRemovedComponent`, and `getMutableComponent` now use optional return types. This lets you use the `entity.getComponent!(MyComponent)` syntax when using Typescript's strict mode instead of `entity.getComponent(MyComponent) as MyComponent`.