### PR TITLE
Component: add AbstractComponent to separate Schema-constructable and raw component

### DIFF
--- a/src/Component.d.ts
+++ b/src/Component.d.ts
@@ -4,27 +4,43 @@ import { PropType } from "./Types";
  * Base class for components.
  */
 
-export type ComponentSchemaProp = {
-  default?: any;
-  type: PropType<any, any>;
+export type ComponentSchemaProp<T> = {
+  default?: T;
+  type: PropType<T, T>;
 };
 
 export type ComponentSchema = {
-  [propName: string]: ComponentSchemaProp;
+  [propName: string]: ComponentSchemaProp<any>;
 };
 
-export class Component<C> {
-  static schema: ComponentSchema;
+export type SchemaProperties<Schema> =
+  Partial<Omit<Schema, keyof Component<Schema>>>;
+
+export class AbstractComponent<Properties> {
   static isComponent: true;
-  constructor(props?: Partial<Omit<C, keyof Component<any>>> | false);
-  copy(source: this): this;
-  clone(): this;
+  static getName(): string;
+  constructor(props?: Properties);
+  copy(source: this | Properties): this;
+  clone(): this
+  setProperties(props?: Properties): this;
   reset(): void;
   dispose(): void;
 }
 
-export interface ComponentConstructor<C extends Component<any>> {
-  schema: ComponentSchema;
+export class Component<Schema>
+  extends AbstractComponent<SchemaProperties<Schema>> {
+  static schema: ComponentSchema;
+  static isSchemaComponent: true;
+  constructor(props?: SchemaProperties<Schema>);
+}
+
+export interface ComponentConstructor<C extends AbstractComponent<any>> {
   isComponent: true;
-  new (props?: Partial<Omit<C, keyof Component<any>>> | false): C;
+  new (...args: any): C;
+}
+
+export interface SchemaConstructable<C extends Component<C>> {
+  schema: ComponentSchema;
+  isSchemaComponent: true;
+  new (props?: SchemaProperties<C>): C;
 }

--- a/src/ComponentManager.js
+++ b/src/ComponentManager.js
@@ -23,21 +23,24 @@ export class ComponentManager {
     }
 
     const schema = Component.schema;
+    if (schema) {
+      for (const propName in schema) {
+        const prop = schema[propName];
+        if (!prop.type) {
+          throw new Error(
+            `Invalid schema for component "${Component.getName()}". Missing type for "${propName}" property.`
+          );
+        }
+      }
+    }
 
-    if (!schema) {
+    console.log(Component.getName());
+    console.log(Component.isSchemaComponent);
+
+    if (Component.isSchemaComponent && !schema) {
       throw new Error(
         `Component "${Component.getName()}" has no schema property.`
       );
-    }
-
-    for (const propName in schema) {
-      const prop = schema[propName];
-
-      if (!prop.type) {
-        throw new Error(
-          `Invalid schema for component "${Component.getName()}". Missing type for "${propName}" property.`
-        );
-      }
     }
 
     Component._typeId = this.nextComponentId++;

--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -19,17 +19,17 @@ export class Entity {
    * @param Component Type of component to get
    * @param includeRemoved Whether a component that is staled to be removed should be also considered
    */
-  getComponent?<C extends Component<any>>(
+  getComponent<C extends Component<any>>(
     Component: ComponentConstructor<C>,
     includeRemoved?: boolean
-  ): Readonly<C>;
+  ): Readonly<C> | undefined;
 
   /**
    * Get a component that is slated to be removed from this entity.
    */
-  getRemovedComponent?<C extends Component<any>>(
+  getRemovedComponent<C extends Component<any>>(
       Component: ComponentConstructor<C>
-  ): Readonly<C>;
+  ): Readonly<C> | undefined;
 
   /**
    * Get an object containing all the components on this entity, where the object keys are the component types.
@@ -50,9 +50,9 @@ export class Entity {
    * Get a mutable reference to a component on this entity.
    * @param Component Type of component to get
    */
-  getMutableComponent?<C extends Component<any>>(
+  getMutableComponent<C extends Component<any>>(
     Component: ComponentConstructor<C>
-  ): C;
+  ): C | undefined;
 
   /**
    * Add a component to the entity.

--- a/src/TagComponent.js
+++ b/src/TagComponent.js
@@ -1,9 +1,15 @@
-import { Component } from "./Component";
+import { AbstractComponent } from "./Component";
 
-export class TagComponent extends Component {
+export class TagComponent extends AbstractComponent {
   constructor() {
-    super(false);
+    super();
   }
+
+  copy() {}
+
+  reset() {}
+
+  setProperties() {}
 }
 
 TagComponent.isTagComponent = true;


### PR DESCRIPTION
Hi,

I quickly worked on adding a way to simplify schema-constructable component, as well as their typings.

## Why?

Before, constructing a component using its schema was made at runtime, see [here](https://github.com/MozillaReality/ecsy/blob/dev/src/Component.js#L3).

Separating the schema-constructable component versus raw component directly on the class makes the component a bit more cleaner I believe. From a TypeScript point of view, it also simplifies things as we can now pass a custom `Properties` object for `AbstractComponent` (see [here](https://github.com/DavidPeicho/ecsy/blob/fix/ts-component/src/Component.d.ts#L22)), while still being able to keep the previous schema properties type on "normal" component (see [here](https://github.com/DavidPeicho/ecsy/blob/fix/ts-component/src/Component.d.ts#L34)).

This PR solves mostly TypeScript issues rather than logic issues. It's really hard to construct component and keep types _as safe as possible_ with the current design.

## Improvements

It's highly possible that this design has some issues. If you think it's a good idea to start with we can go this route, and improve it with the community feedback.

