### PR TITLE
Implement `getComponentOrThrow` methods on `Entity`

### DIFF
--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -25,10 +25,20 @@ export class Entity {
   ): Readonly<C> | undefined;
 
   /**
+   * Get an immutable reference to a component on this entity. Throws if the component is not on the entity.
+   * @param Component Type of component to get
+   * @param includeRemoved Whether a component that is staled to be removed should be also considered
+   */
+  getComponentOrThrow<C extends Component<any>>(
+    Component: ComponentConstructor<C>,
+    includeRemoved?: boolean
+  ): Readonly<C>;
+
+  /**
    * Get a component that is slated to be removed from this entity.
    */
   getRemovedComponent<C extends Component<any>>(
-      Component: ComponentConstructor<C>
+    Component: ComponentConstructor<C>
   ): Readonly<C> | undefined;
 
   /**
@@ -53,6 +63,14 @@ export class Entity {
   getMutableComponent<C extends Component<any>>(
     Component: ComponentConstructor<C>
   ): C | undefined;
+
+  /**
+   * Get a mutable reference to a component on this entity. Throws if the component is not on the entity.
+   * @param Component Type of component to get
+   */
+  getMutableComponent<C extends Component<any>>(
+    Component: ComponentConstructor<C>
+  ): C;
 
   /**
    * Add a component to the entity.
@@ -96,37 +114,29 @@ export class Entity {
    * Check if the entity has all components in a list.
    * @param Components Component types to check
    */
-  hasAllComponents(
-    Components: Array<ComponentConstructor<any>>
-  ): boolean
+  hasAllComponents(Components: Array<ComponentConstructor<any>>): boolean;
 
   /**
    * Check if the entity has any of the components in a list.
    * @param Components Component types to check
    */
-  hasAnyComponents(
-    Components: Array<ComponentConstructor<any>>
-  ): boolean
+  hasAnyComponents(Components: Array<ComponentConstructor<any>>): boolean;
 
   /**
    * Remove all components on this entity.
    * @param forceImmediate Whether all components should be removed immediately
    */
-  removeAllComponents(
-      forceImmediate?: boolean
-  ): void
+  removeAllComponents(forceImmediate?: boolean): void;
 
-  copy(source: this): this
+  copy(source: this): this;
 
-  clone(): this
+  clone(): this;
 
-  reset(): void
+  reset(): void;
 
   /**
    * Remove this entity from the world.
    * @param forceImmediate Whether this entity should be removed immediately
    */
-  remove(
-      forceImmediate?: boolean
-  ): void;
+  remove(forceImmediate?: boolean): void;
 }

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -42,8 +42,8 @@ export class Entity {
       : component;
   }
 
-  getComponentOrThrow(Component) {
-    const component = this.getComponent(Component);
+  getComponentOrThrow(Component, includeRemoved) {
+    const component = this.getComponent(Component, includeRemoved);
     if (!component) {
       throw new Error(
         `Entity ${this.id} does not have component ${Component.getName()}.`

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -84,6 +84,16 @@ export class Entity {
     return component;
   }
 
+  getMutableComponentOrThrow(Component) {
+    const component = this.getMutableComponent(Component);
+    if (!component) {
+      throw new Error(
+        `Entity ${this.id} does not have component ${Component.getName()}.`
+      );
+    }
+    return component;
+  }
+
   addComponent(Component, values) {
     this._entityManager.entityAddComponent(this, Component, values);
     return this;

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -42,6 +42,16 @@ export class Entity {
       : component;
   }
 
+  getComponentOrThrow(Component) {
+    const component = this.getComponent(Component);
+    if (!component) {
+      throw new Error(
+        `Entity ${this.id} does not have component ${Component.getName()}.`
+      );
+    }
+    return component;
+  }
+
   getRemovedComponent(Component) {
     const component = this._componentsToRemove[Component._typeId];
 


### PR DESCRIPTION
This PR adds `getComponentOrThrow` and `getMutableComponentOrThrow` methods on `Entity` so that we can throw a developer-friendly error message when we're trying to access a component that doesn't exist on an entity.

### Typescript

#### Before

Typescript users currently need to either:
1. Write a type guard for every single `getComponent`/`getMutableComponent` call.
   ```ts
   const aabb = myEntity.getComponent<AABBComp>(AABBComp); // AABBComp | undefined
   if (!aabb) {
     throw new Error(`Component ${AABBComp.getName() is not on entity ${myEntity.id}.}`);
   }
   aabb; // AABBComp
   ```
1. Or use non-null assertions (which defeats the purpose of using TS in strict null check mode)
   ```ts
   const aabb = myEntity.getComponent<AABBComp>(AABBComp)!;
   //                                                    ^ :-(
   ```

#### After

```ts
const aabb = myEntity.getComponentOrThrow<AABBComp>(AABBComp); // AABBComp
```

### Notes for reviewer

I'm not sure if creating separate methods is a good idea. Alternatively, we can add/modify the params for the existing component getter methods on `Entity`.

For example, adding a new param:
```js
myEntity.getComponent(AABBComp, false, false);
//                                     ^^^^^ this param can be used to indicate
//                                           if the method should throw
```

I'll write the tests if this gets the green light.